### PR TITLE
[COS-7598] Fix custom field not included when using CreateMoment

### DIFF
--- a/internal/mod/rule/handler.go
+++ b/internal/mod/rule/handler.go
@@ -401,6 +401,7 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo) {
 			Duration:    duration,
 			Code:        moment.Code,
 			RuleName:    ruleName,
+			Metadata:    moment.CustomFields,
 		}
 
 		if moment.CreateTask {


### PR DESCRIPTION
Fix by adding CustomField in CollectInfo's Metadata

Tests done manually.