### PR TITLE
[COS-7594] Fix Labels Not Uploaded With Record

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -362,6 +362,14 @@ func (r *RequestClient) CreateRecord(parent string, rc *openDpsV1alpha1Resource.
 		log.Errorf("unable to save record cache: %v", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("unable to save record cache"))
 	}
+
+	for _, label := range rc.GetLabels() {
+		_, err := r.ensureLabel(parent, label.GetDisplayName())
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return apiRes.Msg, nil
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -350,6 +350,17 @@ func (r *RequestClient) CreateRecord(parent string, rc *openDpsV1alpha1Resource.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	// record's labels may have not been ensured
+	recordLabels := rc.GetLabels()
+	for _, label := range recordLabels {
+		l, err := r.ensureLabel(parent, label.GetDisplayName())
+		if err != nil {
+			return nil, err
+		}
+		recordLabels = append(recordLabels, l)
+	}
+	rc.SetLabels(recordLabels)
+
 	req := openDpsV1alpha1Service.CreateRecordRequest{
 		Parent: parent,
 		Record: rc,
@@ -361,13 +372,6 @@ func (r *RequestClient) CreateRecord(parent string, rc *openDpsV1alpha1Resource.
 	if err != nil {
 		log.Errorf("unable to save record cache: %v", err)
 		return nil, connect.NewError(connect.CodeInternal, errors.New("unable to save record cache"))
-	}
-
-	for _, label := range rc.GetLabels() {
-		_, err := r.ensureLabel(parent, label.GetDisplayName())
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return apiRes.Msg, nil

--- a/internal/collector/upload.go
+++ b/internal/collector/upload.go
@@ -143,7 +143,9 @@ func uploadFiles(reqClient *api.RequestClient, confManager *config.ConfManager, 
 	if allCompleted {
 		log.Infof("upload all files successfully")
 
-		_, err := reqClient.UpdateRecordLabels(recordCache.ProjectName, recordName, []string{constant.LabelUploadSuccess})
+		labels := append(recordCache.Labels, constant.LabelUploadSuccess)
+
+		_, err := reqClient.UpdateRecordLabels(recordCache.ProjectName, recordName, labels)
 		if err != nil {
 			log.Errorf("failed to update record labels: %v", err)
 			return err

--- a/internal/collector/upload.go
+++ b/internal/collector/upload.go
@@ -143,7 +143,9 @@ func uploadFiles(reqClient *api.RequestClient, confManager *config.ConfManager, 
 	if allCompleted {
 		log.Infof("upload all files successfully")
 
-		labels := append(recordCache.Labels, constant.LabelUploadSuccess)
+		var labels []string
+		labels = append(labels, recordCache.Labels...)
+		labels = append(labels, constant.LabelUploadSuccess)
 
 		_, err := reqClient.UpdateRecordLabels(recordCache.ProjectName, recordName, labels)
 		if err != nil {


### PR DESCRIPTION
The labels are not uploaded with record because the labels in `RecordCache` are overridden by `LabelUploadSuccess`.

Test done manually.