### PR TITLE
fix: reset stale multipart upload state

### DIFF
--- a/pkg/upload/upload_manager.go
+++ b/pkg/upload/upload_manager.go
@@ -52,6 +52,17 @@ type FileUploadProgress struct {
 	TotalSize int64
 }
 
+func shouldResetMultipartUpload(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "invalid upload id") ||
+		strings.Contains(message, "the specified multipart upload does not exist") ||
+		strings.Contains(message, "not read all parts")
+}
+
 // Manager is a manager for uploading files through minio client.
 // Note that it's user's responsibility to check the Errs field after Wait() to see if there's any error.
 type Manager struct {
@@ -331,8 +342,7 @@ func (u *Manager) FMultipartPutObject(ctx context.Context, uploadSessionID strin
 			_, err = c.CompleteMultipartUpload(ctx, bucket, key, uploadId, parts, opts)
 			if err != nil {
 				logger.Errorf("Complete multipart upload failed: %v", err)
-				if strings.Contains(strings.ToLower(err.Error()), strings.ToLower("Invalid upload id")) ||
-					strings.Contains(strings.ToLower(err.Error()), strings.ToLower("The specified multipart upload does not exist")) {
+				if shouldResetMultipartUpload(err) {
 					u.cleanUploadCache(uploadIdKey, partsKey, uploadedSizeKey)
 					u.cleanUploadCache(legacyUploadIDKey, legacyPartsKey, legacyUploadedSizeKey)
 				}
@@ -485,7 +495,7 @@ func (u *Manager) FMultipartPutObject(ctx context.Context, uploadSessionID strin
 			completedParts++
 			if uploadRes.Error != nil {
 				cancelUpload()
-				if strings.Contains(strings.ToLower(uploadRes.Error.Error()), strings.ToLower("Invalid upload id")) {
+				if shouldResetMultipartUpload(uploadRes.Error) {
 					u.cleanUploadCache(uploadIdKey, partsKey, uploadedSizeKey)
 					u.cleanUploadCache(legacyUploadIDKey, legacyPartsKey, legacyUploadedSizeKey)
 				}
@@ -539,11 +549,10 @@ func (u *Manager) FMultipartPutObject(ctx context.Context, uploadSessionID strin
 	_, err = c.CompleteMultipartUpload(ctx, bucket, key, uploadId, parts, opts)
 	if err != nil {
 		logger.Errorf("Complete multipart upload failed: %v", err)
-		if strings.Contains(strings.ToLower(err.Error()), strings.ToLower("Invalid upload id")) ||
-			strings.Contains(strings.ToLower(err.Error()), strings.ToLower("The specified multipart upload does not exist")) {
+		if shouldResetMultipartUpload(err) {
 			u.cleanUploadCache(uploadIdKey, partsKey, uploadedSizeKey)
 			u.cleanUploadCache(legacyUploadIDKey, legacyPartsKey, legacyUploadedSizeKey)
-			return errors.Wrapf(err, "Complete multipart upload failed with invalid upload id, cache cleared")
+			return errors.Wrapf(err, "Complete multipart upload failed with stale multipart state, cache cleared")
 		}
 
 		return errors.Wrapf(err, "Complete multipart upload failed")

--- a/pkg/upload/upload_manager_test.go
+++ b/pkg/upload/upload_manager_test.go
@@ -32,6 +32,13 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
+var (
+	errInvalidUploadID         = errors.New("invalid upload id")
+	errMultipartUploadNotFound = errors.New("the specified multipart upload does not exist")
+	errMultipartPartsMissing   = errors.New("we encountered an internal error, please try again.: cause(not read all parts, current: 2)")
+	errUnrelatedInternal       = errors.New("we encountered an internal error, please try again")
+)
+
 func TestUploadManagerCloseStopsProgressHandler(t *testing.T) {
 	t.Parallel()
 
@@ -97,10 +104,10 @@ func TestShouldResetMultipartUpload(t *testing.T) {
 		err  error
 		want bool
 	}{
-		{name: "invalid upload ID", err: errors.New("Invalid upload id"), want: true},
-		{name: "missing multipart upload", err: errors.New("The specified multipart upload does not exist"), want: true},
-		{name: "server did not receive all parts", err: errors.New("We encountered an internal error, please try again.: cause(not read all parts, current: 2)"), want: true},
-		{name: "unrelated internal error", err: errors.New("We encountered an internal error, please try again"), want: false},
+		{name: "invalid upload ID", err: errInvalidUploadID, want: true},
+		{name: "missing multipart upload", err: errMultipartUploadNotFound, want: true},
+		{name: "server did not receive all parts", err: errMultipartPartsMissing, want: true},
+		{name: "unrelated internal error", err: errUnrelatedInternal, want: false},
 		{name: "no error", err: nil, want: false},
 	}
 

--- a/pkg/upload/upload_manager_test.go
+++ b/pkg/upload/upload_manager_test.go
@@ -89,6 +89,31 @@ func TestUploadManagerCloseDoesNotBlockWhenNetworkChannelIsFull(t *testing.T) {
 	}
 }
 
+func TestShouldResetMultipartUpload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "invalid upload ID", err: errors.New("Invalid upload id"), want: true},
+		{name: "missing multipart upload", err: errors.New("The specified multipart upload does not exist"), want: true},
+		{name: "server did not receive all parts", err: errors.New("We encountered an internal error, please try again.: cause(not read all parts, current: 2)"), want: true},
+		{name: "unrelated internal error", err: errors.New("We encountered an internal error, please try again"), want: false},
+		{name: "no error", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldResetMultipartUpload(tt.err); got != tt.want {
+				t.Fatalf("shouldResetMultipartUpload() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFPutObjectSinglePutUsesFixedUploadSize(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Multipart uploads now recover when the server has discarded an upload session or reports that it did not receive every part. Previously, the client retained its locally complete multipart state and could repeatedly retry the same invalid upload ID.

Recognized stale-session errors now clear both scoped and legacy multipart caches so the next collector cycle starts a fresh upload. Unrelated internal server errors continue to preserve resumable state.

## Testing

- `go test ./... -count=1`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coScout/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786262112&installation_id=141984720&pr_number=217&repository=coscene-io%2FcoScout&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoScout%2Fpull%2F217&signature=3ea94d23a8bc1e5952b1b2b502f2d645bcf91cb5083584f9f66a7dbeb1509332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->