### PR TITLE
fix: reclaim unused record cache locks

### DIFF
--- a/internal/model/record_cache_lock.go
+++ b/internal/model/record_cache_lock.go
@@ -22,12 +22,17 @@ import (
 
 type keyedMutexRegistry struct {
 	mu    sync.Mutex
-	locks map[string]*sync.Mutex
+	locks map[string]*keyedMutex
+}
+
+type keyedMutex struct {
+	mu         sync.Mutex
+	references int
 }
 
 func newKeyedMutexRegistry() *keyedMutexRegistry {
 	return &keyedMutexRegistry{
-		locks: make(map[string]*sync.Mutex),
+		locks: make(map[string]*keyedMutex),
 	}
 }
 
@@ -40,13 +45,33 @@ func (r *keyedMutexRegistry) Lock(key string) func() {
 	r.mu.Lock()
 	lock, ok := r.locks[key]
 	if !ok {
-		lock = &sync.Mutex{}
+		lock = &keyedMutex{}
 		r.locks[key] = lock
 	}
+	lock.references++
 	r.mu.Unlock()
 
-	lock.Lock()
-	return lock.Unlock
+	lock.mu.Lock()
+
+	var releaseOnce sync.Once
+	return func() {
+		releaseOnce.Do(func() {
+			r.release(key, lock)
+		})
+	}
+}
+
+func (r *keyedMutexRegistry) release(key string, lock *keyedMutex) {
+	// Keep the registry locked until the keyed mutex is unlocked. When the last
+	// reference is removed, a new caller cannot create a replacement entry
+	// until the old mutex no longer has a holder.
+	r.mu.Lock()
+	lock.references--
+	if lock.references == 0 && r.locks[key] == lock {
+		delete(r.locks, key)
+	}
+	lock.mu.Unlock()
+	r.mu.Unlock()
 }
 
 var recordCacheFileLocks = newKeyedMutexRegistry() //nolint:gochecknoglobals // package-level singleton registry for record cache file locking

--- a/internal/model/record_cache_lock_test.go
+++ b/internal/model/record_cache_lock_test.go
@@ -15,15 +15,19 @@
 package model
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
+
+const testRecordCachePath = "/tmp/record/.cos/state.json"
 
 func TestKeyedMutexRegistrySerializesSameKey(t *testing.T) {
 	t.Parallel()
 
 	registry := newKeyedMutexRegistry()
-	unlock := registry.Lock("/tmp/record/.cos/state.json")
+	unlock := registry.Lock(testRecordCachePath)
 
 	acquired := make(chan struct{})
 	go func() {
@@ -45,4 +49,212 @@ func TestKeyedMutexRegistrySerializesSameKey(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("lock for the same key was not released")
 	}
+}
+
+func TestKeyedMutexRegistrySerializesConcurrentHolders(t *testing.T) {
+	t.Parallel()
+
+	const contenders = 8
+
+	registry := newKeyedMutexRegistry()
+	key := testRecordCachePath
+	releaseHolder := registry.Lock(key)
+	start := make(chan struct{})
+	entered := make(chan struct{}, contenders)
+	leave := make(chan struct{})
+	var waiters sync.WaitGroup
+	waiters.Add(contenders)
+
+	for i := range contenders {
+		go func(index int) {
+			defer waiters.Done()
+			<-start
+
+			key := testRecordCachePath
+			if index%2 == 0 {
+				key = "/tmp/record/.cos/../.cos/state.json"
+			}
+			release := registry.Lock(key)
+			defer release()
+
+			entered <- struct{}{}
+			<-leave
+		}(i)
+	}
+
+	close(start)
+	waitForKeyedMutexReferences(t, registry, key, contenders+1)
+	select {
+	case <-entered:
+		t.Fatal("a contender acquired the lock while the initial holder still owned it")
+	default:
+	}
+	releaseHolder()
+
+	for i := range contenders {
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatalf("contender %d did not acquire the lock", i)
+		}
+
+		select {
+		case <-entered:
+			t.Fatal("multiple goroutines held the same keyed lock concurrently")
+		case <-time.After(20 * time.Millisecond):
+		}
+		leave <- struct{}{}
+	}
+	waiters.Wait()
+}
+
+func TestKeyedMutexRegistryRetainsEntryForHolderAndWaiter(t *testing.T) {
+	t.Parallel()
+
+	registry := newKeyedMutexRegistry()
+	key := testRecordCachePath
+	releaseHolder := registry.Lock(key)
+
+	waiterStarted := make(chan struct{})
+	waiterAcquired := make(chan struct{})
+	releaseWaiter := make(chan struct{})
+	waiterDone := make(chan struct{})
+	go func() {
+		defer close(waiterDone)
+		close(waiterStarted)
+		release := registry.Lock(key)
+		defer release()
+		close(waiterAcquired)
+		<-releaseWaiter
+	}()
+
+	<-waiterStarted
+	waitForKeyedMutexReferences(t, registry, key, 2)
+	select {
+	case <-waiterAcquired:
+		t.Fatal("waiter acquired the lock while the holder still owned it")
+	default:
+	}
+
+	releaseHolder()
+	select {
+	case <-waiterAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("waiter did not acquire the released lock")
+	}
+
+	if got := keyedMutexRegistrySize(registry); got != 1 {
+		t.Fatalf("registry should retain the entry while the waiter holds it, got %d entries", got)
+	}
+	if got := keyedMutexRegistryReferences(registry, key); got != 1 {
+		t.Fatalf("registry should count the waiter as the only reference after acquisition, got %d", got)
+	}
+
+	thirdAcquired := make(chan struct{})
+	releaseThird := make(chan struct{})
+	thirdDone := make(chan struct{})
+	go func() {
+		defer close(thirdDone)
+		release := registry.Lock(key)
+		close(thirdAcquired)
+		<-releaseThird
+		release()
+	}()
+
+	waitForKeyedMutexReferences(t, registry, key, 2)
+	select {
+	case <-thirdAcquired:
+		t.Fatal("a new caller acquired a replacement lock while the waiter still held the key")
+	default:
+	}
+
+	close(releaseWaiter)
+	<-waiterDone
+	select {
+	case <-thirdAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("new caller did not acquire the key after the waiter released it")
+	}
+	if got := keyedMutexRegistryReferences(registry, key); got != 1 {
+		t.Fatalf("registry should count the new caller as the only reference, got %d", got)
+	}
+
+	close(releaseThird)
+	<-thirdDone
+	if got := keyedMutexRegistrySize(registry); got != 0 {
+		t.Fatalf("registry should remove the entry after the last release, got %d entries", got)
+	}
+}
+
+func TestKeyedMutexRegistryReclaimsUnusedKeys(t *testing.T) {
+	t.Parallel()
+
+	const keyCount = 1_000
+
+	registry := newKeyedMutexRegistry()
+	var waiters sync.WaitGroup
+	waiters.Add(keyCount)
+	for i := range keyCount {
+		go func(index int) {
+			defer waiters.Done()
+			release := registry.Lock(fmt.Sprintf("/tmp/record-%d/.cos/state.json", index))
+			release()
+		}(i)
+	}
+	waiters.Wait()
+
+	if got := keyedMutexRegistrySize(registry); got != 0 {
+		t.Fatalf("registry retained %d unused keyed locks", got)
+	}
+}
+
+func TestKeyedMutexRegistryReleaseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	registry := newKeyedMutexRegistry()
+	release := registry.Lock(testRecordCachePath)
+	release()
+	release()
+
+	if got := keyedMutexRegistrySize(registry); got != 0 {
+		t.Fatalf("registry retained %d entries after repeated release", got)
+	}
+
+	release = registry.Lock(testRecordCachePath)
+	release()
+	if got := keyedMutexRegistrySize(registry); got != 0 {
+		t.Fatalf("registry retained %d entries after key reuse", got)
+	}
+}
+
+func keyedMutexRegistrySize(registry *keyedMutexRegistry) int {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	return len(registry.locks)
+}
+
+func waitForKeyedMutexReferences(t *testing.T, registry *keyedMutexRegistry, key string, expected int) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		if got := keyedMutexRegistryReferences(registry, key); got == expected {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("keyed lock did not reach %d references", expected)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func keyedMutexRegistryReferences(registry *keyedMutexRegistry, key string) int {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	lock := registry.locks[key]
+	if lock == nil {
+		return 0
+	}
+	return lock.references
 }


### PR DESCRIPTION
## Summary

Record-cache cleanup no longer leaves every historical `state.json` path resident in process memory. The keyed-lock registry now retains an entry only while a holder or queued waiter exists, then reclaims it after the final release without allowing a second mutex for the same path.

Release callbacks are idempotent, preserving the existing caller API. All five current call sites defer release across success, error, and early-return paths; callers must continue to invoke the returned release function.

## Validation

- `go test -race ./internal/model -run 'TestKeyedMutexRegistry' -count=50`
- `make test`
- `make testrace`
- `go vet ./...`
- `make lint`

Coverage includes normalized same-path mutual exclusion, holder/waiter/third-caller lifecycle, ABA-safe key reuse, repeated release, and reclamation after 1,000 distinct paths.

## Post-Deploy Monitoring & Validation

- Watch coScout process RSS or heap profiles during record-cache churn; memory should stop growing in proportion to historical cache paths.
- Search service logs for mutex panics, record-cache read/write failures, or unexpected concurrent `state.json` updates.
- Treat sustained heap growth tied to keyed-lock entries, mutex panics, or corrupted cache state as rollback/mitigation triggers.
- Validation window: first 24 hours after deployment; owner: coScout service maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coScout/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787829604&installation_model_id=425002&pr_number=224&repository=coscene-io%2FcoScout&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoScout%2Fpull%2F224&signature=e2049fbcfae11af5188adc58808de52cb2f8269d537a49ab74f42cb662ba7a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->