### PR TITLE
fix(scan): preserve semantics in streaming file scans

### DIFF
--- a/internal/master/types.go
+++ b/internal/master/types.go
@@ -202,10 +202,35 @@ type TaskRequest struct {
 
 // TaskResponse task response structure.
 type TaskResponse struct {
-	TaskID  string          `json:"task_id"`
-	Files   []SlaveFileInfo `json:"files"`
-	Success bool            `json:"success"`
-	Error   string          `json:"error,omitempty"`
+	TaskID    string          `json:"task_id"`
+	Files     []SlaveFileInfo `json:"files"`
+	Success   bool            `json:"success"`
+	ErrorCode string          `json:"error_code,omitempty"`
+	Error     string          `json:"error,omitempty"`
+}
+
+const (
+	TaskErrorCodeInvalidTimeWindow  = "INVALID_TIME_WINDOW"
+	TaskErrorCodeTimeWindowNotReady = "TIME_WINDOW_NOT_READY"
+)
+
+// TaskResponsesTimeWindowErrorCode returns the strongest time-window status
+// reported by any slave. Permanent invalidity takes precedence over a
+// retryable not-ready result.
+func TaskResponsesTimeWindowErrorCode(responses map[string]*TaskResponse) string {
+	result := ""
+	for _, response := range responses {
+		if response == nil || response.Success {
+			continue
+		}
+		switch response.ErrorCode {
+		case TaskErrorCodeInvalidTimeWindow:
+			return TaskErrorCodeInvalidTimeWindow
+		case TaskErrorCodeTimeWindowNotReady:
+			result = TaskErrorCodeTimeWindowNotReady
+		}
+	}
+	return result
 }
 
 // HeartbeatRequest heartbeat request structure.

--- a/internal/master/types.go
+++ b/internal/master/types.go
@@ -215,8 +215,8 @@ const (
 )
 
 // TaskResponsesTimeWindowErrorCode returns the strongest time-window status
-// reported by any slave. Permanent invalidity takes precedence over a
-// retryable not-ready result.
+// reported by any slave. Permanent invalidity takes precedence over a legacy
+// not-ready result from an older slave.
 func TaskResponsesTimeWindowErrorCode(responses map[string]*TaskResponse) string {
 	result := ""
 	for _, response := range responses {

--- a/internal/master/types_test.go
+++ b/internal/master/types_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package master
+
+import "testing"
+
+func TestTaskResponsesTimeWindowErrorCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		responses map[string]*TaskResponse
+		want      string
+	}{
+		{
+			name: "no time error",
+			responses: map[string]*TaskResponse{
+				"successful": {Success: true, ErrorCode: TaskErrorCodeInvalidTimeWindow},
+				"other":      {Success: false, ErrorCode: "OTHER"},
+			},
+		},
+		{
+			name: "retryable not ready",
+			responses: map[string]*TaskResponse{
+				"future": {ErrorCode: TaskErrorCodeTimeWindowNotReady},
+			},
+			want: TaskErrorCodeTimeWindowNotReady,
+		},
+		{
+			name: "permanent invalid takes precedence",
+			responses: map[string]*TaskResponse{
+				"future":  {ErrorCode: TaskErrorCodeTimeWindowNotReady},
+				"invalid": {ErrorCode: TaskErrorCodeInvalidTimeWindow},
+			},
+			want: TaskErrorCodeInvalidTimeWindow,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := TaskResponsesTimeWindowErrorCode(tc.responses); got != tc.want {
+				t.Fatalf("TaskResponsesTimeWindowErrorCode() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/master/types_test.go
+++ b/internal/master/types_test.go
@@ -32,7 +32,7 @@ func TestTaskResponsesTimeWindowErrorCode(t *testing.T) {
 			},
 		},
 		{
-			name: "retryable not ready",
+			name: "legacy not ready",
 			responses: map[string]*TaskResponse{
 				"future": {ErrorCode: TaskErrorCodeTimeWindowNotReady},
 			},

--- a/internal/mod/rule/file_state_handler/file_state_handler.go
+++ b/internal/mod/rule/file_state_handler/file_state_handler.go
@@ -102,6 +102,11 @@ type fileStateHandler struct {
 	handlers     []file_handlers.Interface
 }
 
+type fileStateCheckpoint struct {
+	state  FileState
+	exists bool
+}
+
 var (
 	//nolint: gochecknoglobals // singleton instances map
 	instances = make(map[string]*fileStateHandler)
@@ -258,6 +263,31 @@ func (f *fileStateHandler) getFileState(filePath string) (FileState, bool) {
 	return state, exists
 }
 
+func (f *fileStateHandler) checkpointFileState(checkpoints map[string]fileStateCheckpoint, filePath string) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		log.Errorf("Failed to get absolute path for %s: %v", filePath, err)
+		return
+	}
+	if _, recorded := checkpoints[absPath]; recorded {
+		return
+	}
+	state, exists := f.getFileState(absPath)
+	checkpoints[absPath] = fileStateCheckpoint{state: state, exists: exists}
+}
+
+func (f *fileStateHandler) restoreFileStates(checkpoints map[string]fileStateCheckpoint) {
+	for filePath, checkpoint := range checkpoints {
+		if checkpoint.exists {
+			f.setFileState(filePath, checkpoint.state)
+			continue
+		}
+		if err := f.delFileState(filePath); err != nil {
+			log.Errorf("Failed to roll back file state for %s: %v", filePath, err)
+		}
+	}
+}
+
 // updateDeletedFileState removes state entries for files that no longer exist.
 func (f *fileStateHandler) updateDeletedFileState() error {
 	for _, filename := range lo.Keys(f.state) {
@@ -308,34 +338,35 @@ func (f *fileStateHandler) UpdateListenDirs(conf config.DefaultModConfConfig) er
 		// Check should recursively walk directories
 		//nolint: nestif // complexity is acceptable for this function
 		if conf.RecursivelyWalkDirs {
-			filePaths, err := utils.GetAllFilePaths(dir, &utils.SymWalkOptions{
+			checkpoints := make(map[string]fileStateCheckpoint)
+			err := utils.WalkFilePaths(dir, &utils.SymWalkOptions{
 				FollowSymlinks:       true,
 				SkipPermissionErrors: true,
 				SkipEmptyFiles:       true,
 				MaxFiles:             99999,
-			})
-
-			if err != nil {
-				log.Errorf("Failed to get all file paths in directory %s, skipping: %v", dir, err)
-				continue
-			}
-
-			for _, entryPath := range filePaths {
+			}, func(entryPath string) error {
 				// Check if the entry is readable
 				if !utils.CheckReadPath(entryPath) {
 					log.Warnf("Skipping file %s due to insufficient permissions", entryPath)
-					continue
+					return nil
 				}
 
 				// Get the entry info
 				d, err := os.Stat(entryPath)
 				if err != nil {
 					log.Errorf("Failed to stat file %s, skipping: %v", entryPath, err)
-					continue
+					return nil
 				}
 
 				// Process the file
+				f.checkpointFileState(checkpoints, entryPath)
 				f.processListenFile(entryPath, d, conf.SkipPeriodHours)
+				return nil
+			})
+			if err != nil {
+				f.restoreFileStates(checkpoints)
+				log.Errorf("Failed to walk files in directory %s, skipping: %v", dir, err)
+				continue
 			}
 		} else {
 			entries, err := os.ReadDir(dir)
@@ -434,39 +465,43 @@ func (f *fileStateHandler) UpdateCollectDirs(whitelist []string, conf config.Def
 		// Check should recursively walk directories
 		//nolint: nestif // complexity is acceptable for this function
 		if conf.RecursivelyWalkDirs {
-			filePaths, err := utils.GetAllFilePaths(dir, &utils.SymWalkOptions{
+			checkpoints := make(map[string]fileStateCheckpoint)
+			err := utils.WalkFilePaths(dir, &utils.SymWalkOptions{
 				FollowSymlinks:       true,
 				SkipPermissionErrors: true,
 				SkipEmptyFiles:       true,
 				MaxFiles:             99999,
-			})
-
-			if err != nil {
-				log.Errorf("Failed to get all file paths in directory %s, skipping: %v", dir, err)
-				continue
-			}
-
-			for _, entryPath := range filePaths {
+			}, func(entryPath string) error {
 				// Check whitelist before processing (saves expensive file operations)
 				if !matchesWhitelist(entryPath) {
-					continue
+					return nil
 				}
 
 				// Check if the entry is readable
 				if !utils.CheckReadPath(entryPath) {
 					log.Warnf("Skipping file %s due to insufficient permissions", entryPath)
-					return nil
+					return filepath.SkipAll
 				}
 
 				// Get the entry info
 				d, err := os.Stat(entryPath)
 				if err != nil {
 					log.Errorf("Failed to stat file %s, skipping: %v", entryPath, err)
-					continue
+					return nil
 				}
 
 				// Process the file
+				f.checkpointFileState(checkpoints, entryPath)
 				f.processCollectFile(entryPath, d)
+				return nil
+			})
+			if errors.Is(err, filepath.SkipAll) {
+				return nil
+			}
+			if err != nil {
+				f.restoreFileStates(checkpoints)
+				log.Errorf("Failed to walk files in directory %s, skipping: %v", dir, err)
+				continue
 			}
 		} else {
 			entries, err := os.ReadDir(dir)

--- a/internal/mod/rule/file_state_handler/file_state_handler_test.go
+++ b/internal/mod/rule/file_state_handler/file_state_handler_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file_state_handler
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/coscene-io/coscout/internal/config"
+	mapset "github.com/deckarep/golang-set/v2"
+)
+
+func TestRecursiveDirectoryUpdatesRollBackAfterLaterTraversalError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		update func(*fileStateHandler, config.DefaultModConfConfig) error
+	}{
+		{
+			name: "listen dirs",
+			update: func(handler *fileStateHandler, conf config.DefaultModConfConfig) error {
+				return handler.UpdateListenDirs(conf)
+			},
+		},
+		{
+			name: "collect dirs",
+			update: func(handler *fileStateHandler, conf config.DefaultModConfConfig) error {
+				return handler.UpdateCollectDirs(nil, conf)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			firstPath := filepath.Join(root, "a-file.txt")
+			if err := os.WriteFile(firstPath, []byte("data"), 0o600); err != nil {
+				t.Fatalf("write first file: %v", err)
+			}
+			if err := os.Symlink(filepath.Join(root, "missing-target"), filepath.Join(root, "z-broken-link")); err != nil {
+				t.Skipf("symlinks unavailable: %v", err)
+			}
+
+			original := FileState{Size: 123, ModifyTime: 456, Unsupported: false}
+			handler := &fileStateHandler{
+				state:        map[string]FileState{firstPath: original},
+				listenDirs:   mapset.NewSet[string](),
+				collectDirs:  mapset.NewSet[string](),
+				activeTopics: mapset.NewSet[string](),
+				statePath:    filepath.Join(t.TempDir(), "state.json"),
+			}
+			conf := config.DefaultModConfConfig{
+				ListenDirs:          []string{root},
+				CollectDirs:         []string{root},
+				RecursivelyWalkDirs: true,
+			}
+
+			if err := tc.update(handler, conf); err != nil {
+				t.Fatalf("directory update error = %v", err)
+			}
+			if !reflect.DeepEqual(handler.state, map[string]FileState{firstPath: original}) {
+				t.Fatalf("state = %#v, want original state restored after later traversal error", handler.state)
+			}
+		})
+	}
+}

--- a/internal/mod/rule/handler.go
+++ b/internal/mod/rule/handler.go
@@ -432,7 +432,10 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 			collectLog.WithFields(log.Fields{
 				"start": info.Cut.Start,
 				"end":   info.Cut.End,
-			}).Infof("collect info is not ready yet, retaining it for a later scan: %v", err)
+			}).Infof("collect info starts beyond the future tolerance and will be consumed as an empty successful scan: %v", err)
+			if cleanedPath := c.clean(info); cleanedPath == "" {
+				collectLog.Errorf("failed to clean future collect info after empty successful scan")
+			}
 			return
 		}
 		collectLog.WithFields(log.Fields{
@@ -525,17 +528,14 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 			}
 			return
 		case master.TaskErrorCodeTimeWindowNotReady:
-			collectLog.Infof("a slave is not ready for the collect info time window, retaining it for a later scan")
-			return
+			collectLog.Infof("a legacy slave reported a not-ready time window; treating that response as empty and continuing with available results")
 		}
-		for slaveID, response := range responses {
-			if response != nil && response.Success {
-				collectLog.WithFields(log.Fields{
-					"slaveID": slaveID,
-					"files":   len(response.Files),
-				}).Infof("slave returned files for rule collection")
-				slaveFiles = append(slaveFiles, response.Files...)
-			}
+		for slaveID, response := range successfulSlaveResponses(responses) {
+			collectLog.WithFields(log.Fields{
+				"slaveID": slaveID,
+				"files":   len(response.Files),
+			}).Infof("slave returned files for rule collection")
+			slaveFiles = append(slaveFiles, response.Files...)
 		}
 		collectLog.WithField("slaveFiles", len(slaveFiles)).Infof("total slave files collected for rule")
 	}
@@ -682,6 +682,16 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 	} else {
 		collectLog.WithField("recordCache", rc.GetRecordCachePath()).Infof("published collect message")
 	}
+}
+
+func successfulSlaveResponses(responses map[string]*master.TaskResponse) map[string]*master.TaskResponse {
+	successful := make(map[string]*master.TaskResponse)
+	for slaveID, response := range responses {
+		if response != nil && response.Success {
+			successful[slaveID] = response
+		}
+	}
+	return successful
 }
 
 func (c *CustomRuleHandler) clean(info model.CollectInfo) string {

--- a/internal/mod/rule/handler.go
+++ b/internal/mod/rule/handler.go
@@ -68,8 +68,14 @@ type CustomRuleHandler struct {
 
 	// Master-slave components (optional)
 	slaveRegistry *master.SlaveRegistry
-	masterClient  *master.Client
+	masterClient  ruleSlaveFileRequester
 	masterConfig  *config.MasterConfig
+
+	cleanCollectInfo func(model.CollectInfo) string
+}
+
+type ruleSlaveFileRequester interface {
+	RequestAllSlaveFilesByContent(context.Context, *master.SlaveRegistry, *master.TaskRequest) map[string]*master.TaskResponse
 }
 
 func NewRuleHandler(reqClient api.RequestClient, confManager config.ConfManager, pubSub *gochannel.GoChannel, errChan chan error) *CustomRuleHandler {
@@ -96,6 +102,9 @@ func NewRuleHandler(reqClient api.RequestClient, confManager config.ConfManager,
 		ruleItemChan:            make(chan rule_engine.RuleItem, 1000),
 		engine:                  Engine{reqClient: reqClient, ruleDebounceTime: make(map[string]*time.Time)},
 		pubSub:                  pubSub,
+		cleanCollectInfo: func(info model.CollectInfo) string {
+			return info.Clean()
+		},
 	}
 }
 
@@ -389,11 +398,6 @@ func (c *CustomRuleHandler) scanCollectInfosAndHandle(modConfig *config.DefaultM
 			continue
 		}
 
-		if time.Unix(collectInfo.Cut.End, 0).After(time.Now()) {
-			log.WithField("collectID", collectInfo.Id).Infof("Collect info end time is not reached, skip!")
-			continue
-		}
-
 		log.WithField("collectID", collectInfo.Id).Infof("Found collect info to handle")
 		c.handleCollectInfo(*collectInfo, *modConfig)
 	}
@@ -413,21 +417,31 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 
 	if info.Skip {
 		collectLog.Infof("skipping collect info, cleaning")
-		info.Clean()
+		c.clean(info)
 		return
 	}
 
 	if info.Cut == nil {
 		collectLog.Errorf("collect info cut is nil, cleaning")
-		info.Clean()
+		c.clean(info)
 		return
 	}
 
-	if time.Unix(info.Cut.End, 0).After(time.Now()) {
+	if err := upload.ValidateTimeWindow(info.Cut.Start, info.Cut.End); err != nil {
+		if errors.Is(err, upload.ErrTimeWindowNotReady) {
+			collectLog.WithFields(log.Fields{
+				"start": info.Cut.Start,
+				"end":   info.Cut.End,
+			}).Infof("collect info is not ready yet, retaining it for a later scan: %v", err)
+			return
+		}
 		collectLog.WithFields(log.Fields{
 			"start": info.Cut.Start,
 			"end":   info.Cut.End,
-		}).Infof("collect info end time is not reached, skip")
+		}).Errorf("collect info has a permanently invalid time window, cleaning: %v", err)
+		if cleanedPath := c.clean(info); cleanedPath == "" {
+			collectLog.Errorf("failed to clean collect info with permanently invalid time window")
+		}
 		return
 	}
 
@@ -443,7 +457,11 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 	if hasBirthTime {
 		collectLog.Infof("at least one collect dir has birth time support")
 
-		uploadFiles, noPermissionFiles := upload.ComputeUploadFiles(info.Id, modConfig.CollectDirs, []string{}, info.Cut.WhiteList, modConfig.RecursivelyWalkDirs, info.Cut.Start, info.Cut.End)
+		uploadFiles, noPermissionFiles, err := upload.ComputeUploadFiles(info.Id, modConfig.CollectDirs, []string{}, info.Cut.WhiteList, modConfig.RecursivelyWalkDirs, info.Cut.Start, info.Cut.End)
+		if err != nil {
+			collectLog.Errorf("collect info scan did not run: %v", err)
+			return
+		}
 		if len(noPermissionFiles) > 0 {
 			collectLog.WithField("files", noPermissionFiles).Infof("found no permission files")
 		}
@@ -499,6 +517,17 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 		}
 
 		responses := c.masterClient.RequestAllSlaveFilesByContent(ctx, c.slaveRegistry, taskReq)
+		switch master.TaskResponsesTimeWindowErrorCode(responses) {
+		case master.TaskErrorCodeInvalidTimeWindow:
+			collectLog.Errorf("a slave rejected the collect info time window as permanently invalid, cleaning")
+			if cleanedPath := c.clean(info); cleanedPath == "" {
+				collectLog.Errorf("failed to clean collect info rejected by slave")
+			}
+			return
+		case master.TaskErrorCodeTimeWindowNotReady:
+			collectLog.Infof("a slave is not ready for the collect info time window, retaining it for a later scan")
+			return
+		}
 		for slaveID, response := range responses {
 			if response != nil && response.Success {
 				collectLog.WithFields(log.Fields{
@@ -637,7 +666,7 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 		"moments":     len(rc.Moments),
 	}).Infof("saved record cache")
 
-	if cleanId := info.Clean(); cleanId == "" {
+	if cleanId := c.clean(info); cleanId == "" {
 		collectLog.WithField("recordCache", rc.GetRecordCachePath()).Errorf("clean collect info failed")
 	} else {
 		collectLog.WithFields(log.Fields{
@@ -653,6 +682,13 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 	} else {
 		collectLog.WithField("recordCache", rc.GetRecordCachePath()).Infof("published collect message")
 	}
+}
+
+func (c *CustomRuleHandler) clean(info model.CollectInfo) string {
+	if c.cleanCollectInfo != nil {
+		return c.cleanCollectInfo(info)
+	}
+	return info.Clean()
 }
 
 // EnhanceRuleHandlerWithMasterSlave adds master-slave support to rule handler.

--- a/internal/mod/rule/handler_test.go
+++ b/internal/mod/rule/handler_test.go
@@ -37,29 +37,19 @@ func TestHandleCollectInfoTimeWindowLifecycle(t *testing.T) {
 		responses     map[string]*master.TaskResponse
 		wantClean     bool
 		wantSlaveCall bool
+		wantStateScan bool
 	}{
 		{
-			name:  "future local window is retained",
-			start: now.Add(10 * time.Minute),
-			end:   now.Add(20 * time.Minute),
+			name:      "future local window is consumed as empty success",
+			start:     now.Add(10 * time.Minute),
+			end:       now.Add(20 * time.Minute),
+			wantClean: true,
 		},
 		{
 			name:      "invalid local window is cleaned",
 			start:     now,
 			end:       now.Add(-time.Minute),
 			wantClean: true,
-		},
-		{
-			name:  "retryable slave window is retained",
-			start: now.Add(-time.Minute),
-			end:   now.Add(time.Minute),
-			responses: map[string]*master.TaskResponse{
-				"future": {
-					Success:   false,
-					ErrorCode: master.TaskErrorCodeTimeWindowNotReady,
-				},
-			},
-			wantSlaveCall: true,
 		},
 		{
 			name:  "invalid slave window wins and is cleaned",
@@ -77,6 +67,7 @@ func TestHandleCollectInfoTimeWindowLifecycle(t *testing.T) {
 			},
 			wantClean:     true,
 			wantSlaveCall: true,
+			wantStateScan: true,
 		},
 	}
 
@@ -86,8 +77,9 @@ func TestHandleCollectInfoTimeWindowLifecycle(t *testing.T) {
 
 			cleaned := false
 			requester := &recordingRuleSlaveFileRequester{responses: tc.responses}
+			fileStates := &recordingRuleFileStateHandler{}
 			handler := &CustomRuleHandler{
-				collectFileStateHandler: emptyRuleFileStateHandler{},
+				collectFileStateHandler: fileStates,
 				slaveRegistry:           master.NewSlaveRegistry(),
 				masterClient:            requester,
 				masterConfig:            &config.MasterConfig{RequestTimeout: time.Second},
@@ -112,7 +104,43 @@ func TestHandleCollectInfoTimeWindowLifecycle(t *testing.T) {
 			if requester.called != tc.wantSlaveCall {
 				t.Fatalf("slave called = %v, want %v", requester.called, tc.wantSlaveCall)
 			}
+			if got := fileStates.updateCalls > 0; got != tc.wantStateScan {
+				t.Fatalf("file state scan = %v, want %v", got, tc.wantStateScan)
+			}
 		})
+	}
+}
+
+func TestSuccessfulSlaveResponsesPreservesResultsAlongsideLegacyNotReady(t *testing.T) {
+	t.Parallel()
+
+	success := &master.TaskResponse{
+		Success: true,
+		Files: []master.SlaveFileInfo{
+			{
+				FileInfo: model.FileInfo{Path: "/var/log/healthy.log"},
+				SlaveID:  "healthy",
+			},
+		},
+	}
+	responses := map[string]*master.TaskResponse{
+		"legacy": {
+			Success:   false,
+			ErrorCode: master.TaskErrorCodeTimeWindowNotReady,
+		},
+		"healthy": success,
+		"missing": nil,
+	}
+
+	got := successfulSlaveResponses(responses)
+	if len(got) != 1 {
+		t.Fatalf("successful response count = %d, want 1", len(got))
+	}
+	if got["healthy"] != success {
+		t.Fatalf("healthy response = %#v, want %#v", got["healthy"], success)
+	}
+	if _, ok := got["legacy"]; ok {
+		t.Fatal("legacy not-ready response was treated as successful")
 	}
 }
 
@@ -130,28 +158,31 @@ func (r *recordingRuleSlaveFileRequester) RequestAllSlaveFilesByContent(
 	return r.responses
 }
 
-type emptyRuleFileStateHandler struct{}
+type recordingRuleFileStateHandler struct {
+	updateCalls int
+}
 
-func (emptyRuleFileStateHandler) UpdateListenDirs(config.DefaultModConfConfig) error {
+func (*recordingRuleFileStateHandler) UpdateListenDirs(config.DefaultModConfConfig) error {
 	return nil
 }
 
-func (emptyRuleFileStateHandler) UpdateCollectDirs([]string, config.DefaultModConfConfig) error {
+func (r *recordingRuleFileStateHandler) UpdateCollectDirs([]string, config.DefaultModConfConfig) error {
+	r.updateCalls++
 	return nil
 }
 
-func (emptyRuleFileStateHandler) Files(...file_state_handler.FileFilter) []file_state_handler.FileState {
+func (*recordingRuleFileStateHandler) Files(...file_state_handler.FileFilter) []file_state_handler.FileState {
 	return nil
 }
 
-func (emptyRuleFileStateHandler) UpdateFilesProcessState() error {
+func (*recordingRuleFileStateHandler) UpdateFilesProcessState() error {
 	return nil
 }
 
-func (emptyRuleFileStateHandler) MarkProcessedFile(string) error {
+func (*recordingRuleFileStateHandler) MarkProcessedFile(string) error {
 	return nil
 }
 
-func (emptyRuleFileStateHandler) GetFileHandler(string) file_handlers.Interface {
+func (*recordingRuleFileStateHandler) GetFileHandler(string) file_handlers.Interface {
 	return nil
 }

--- a/internal/mod/rule/handler_test.go
+++ b/internal/mod/rule/handler_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coscene-io/coscout/internal/config"
+	"github.com/coscene-io/coscout/internal/master"
+	"github.com/coscene-io/coscout/internal/mod/rule/file_handlers"
+	"github.com/coscene-io/coscout/internal/mod/rule/file_state_handler"
+	"github.com/coscene-io/coscout/internal/model"
+)
+
+func TestHandleCollectInfoTimeWindowLifecycle(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	tests := []struct {
+		name          string
+		start         time.Time
+		end           time.Time
+		responses     map[string]*master.TaskResponse
+		wantClean     bool
+		wantSlaveCall bool
+	}{
+		{
+			name:  "future local window is retained",
+			start: now.Add(10 * time.Minute),
+			end:   now.Add(20 * time.Minute),
+		},
+		{
+			name:      "invalid local window is cleaned",
+			start:     now,
+			end:       now.Add(-time.Minute),
+			wantClean: true,
+		},
+		{
+			name:  "retryable slave window is retained",
+			start: now.Add(-time.Minute),
+			end:   now.Add(time.Minute),
+			responses: map[string]*master.TaskResponse{
+				"future": {
+					Success:   false,
+					ErrorCode: master.TaskErrorCodeTimeWindowNotReady,
+				},
+			},
+			wantSlaveCall: true,
+		},
+		{
+			name:  "invalid slave window wins and is cleaned",
+			start: now.Add(-time.Minute),
+			end:   now.Add(time.Minute),
+			responses: map[string]*master.TaskResponse{
+				"future": {
+					Success:   false,
+					ErrorCode: master.TaskErrorCodeTimeWindowNotReady,
+				},
+				"invalid": {
+					Success:   false,
+					ErrorCode: master.TaskErrorCodeInvalidTimeWindow,
+				},
+			},
+			wantClean:     true,
+			wantSlaveCall: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cleaned := false
+			requester := &recordingRuleSlaveFileRequester{responses: tc.responses}
+			handler := &CustomRuleHandler{
+				collectFileStateHandler: emptyRuleFileStateHandler{},
+				slaveRegistry:           master.NewSlaveRegistry(),
+				masterClient:            requester,
+				masterConfig:            &config.MasterConfig{RequestTimeout: time.Second},
+				cleanCollectInfo: func(model.CollectInfo) string {
+					cleaned = true
+					return "cleaned"
+				},
+			}
+			info := model.CollectInfo{
+				Id: "collect-info",
+				Cut: &model.CollectInfoCut{
+					Start: tc.start.Unix(),
+					End:   tc.end.Unix(),
+				},
+			}
+
+			handler.handleCollectInfo(info, config.DefaultModConfConfig{})
+
+			if cleaned != tc.wantClean {
+				t.Fatalf("cleaned = %v, want %v", cleaned, tc.wantClean)
+			}
+			if requester.called != tc.wantSlaveCall {
+				t.Fatalf("slave called = %v, want %v", requester.called, tc.wantSlaveCall)
+			}
+		})
+	}
+}
+
+type recordingRuleSlaveFileRequester struct {
+	responses map[string]*master.TaskResponse
+	called    bool
+}
+
+func (r *recordingRuleSlaveFileRequester) RequestAllSlaveFilesByContent(
+	context.Context,
+	*master.SlaveRegistry,
+	*master.TaskRequest,
+) map[string]*master.TaskResponse {
+	r.called = true
+	return r.responses
+}
+
+type emptyRuleFileStateHandler struct{}
+
+func (emptyRuleFileStateHandler) UpdateListenDirs(config.DefaultModConfConfig) error {
+	return nil
+}
+
+func (emptyRuleFileStateHandler) UpdateCollectDirs([]string, config.DefaultModConfConfig) error {
+	return nil
+}
+
+func (emptyRuleFileStateHandler) Files(...file_state_handler.FileFilter) []file_state_handler.FileState {
+	return nil
+}
+
+func (emptyRuleFileStateHandler) UpdateFilesProcessState() error {
+	return nil
+}
+
+func (emptyRuleFileStateHandler) MarkProcessedFile(string) error {
+	return nil
+}
+
+func (emptyRuleFileStateHandler) GetFileHandler(string) file_handlers.Interface {
+	return nil
+}

--- a/internal/mod/task/handler.go
+++ b/internal/mod/task/handler.go
@@ -212,7 +212,14 @@ func (c *CustomTaskHandler) handlePendingTasks(tasks []*openDpsV1alpha1Resource.
 			err := upload.ValidateTimeWindow(taskDetail.GetStartTime().AsTime().Unix(), taskDetail.GetEndTime().AsTime().Unix())
 			switch {
 			case errors.Is(err, upload.ErrTimeWindowNotReady):
-				log.WithField("taskName", task.GetName()).Infof("Upload task is not ready yet, keeping it pending: %v", err)
+				log.WithField("taskName", task.GetName()).Infof("Upload task starts beyond the future tolerance and will complete as an empty successful scan: %v", err)
+				if _, updateErr := c.reqClient.UpdateTaskState(task.GetName(), enums.TaskStateEnum_PROCESSING.Enum()); updateErr != nil {
+					log.WithField("taskName", task.GetName()).Errorf("Failed to update task state: %v", updateErr)
+					continue
+				}
+				if _, updateErr := c.reqClient.UpdateTaskState(task.GetName(), enums.TaskStateEnum_SUCCEEDED.Enum()); updateErr != nil {
+					log.WithField("taskName", task.GetName()).Errorf("Failed to update task state: %v", updateErr)
+				}
 				continue
 			case errors.Is(err, upload.ErrInvalidTimeWindow):
 				log.WithField("taskName", task.GetName()).Errorf("Upload task has a permanently invalid time window: %v", err)
@@ -286,8 +293,7 @@ func (c *CustomTaskHandler) handleUploadTask(task *openDpsV1alpha1Resource.Task)
 			}
 			return
 		case master.TaskErrorCodeTimeWindowNotReady:
-			log.WithField("taskName", task.GetName()).Info("A slave is not ready for the upload time window, keeping task pending")
-			return
+			log.WithField("taskName", task.GetName()).Info("A legacy slave reported a not-ready time window; treating its response as an empty successful result")
 		}
 		for slaveID, response := range responses {
 			if response != nil && response.Success {

--- a/internal/mod/task/handler.go
+++ b/internal/mod/task/handler.go
@@ -16,6 +16,7 @@ package task
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -35,23 +36,34 @@ import (
 	"github.com/coscene-io/coscout/pkg/upload"
 	"github.com/coscene-io/coscout/pkg/utils"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+type requestClient interface {
+	ListDeviceTasks(deviceName string, state *enums.TaskStateEnum_TaskState, category string) ([]*openDpsV1alpha1Resource.Task, error)
+	UpdateTaskState(name string, state *enums.TaskStateEnum_TaskState) (*openDpsV1alpha1Resource.Task, error)
+	AddTaskTags(task string, tags map[string]string) (*emptypb.Empty, error)
+}
+
+type slaveFileRequester interface {
+	RequestAllSlaveFiles(context.Context, *master.SlaveRegistry, *master.TaskRequest) map[string]*master.TaskResponse
+}
+
 type CustomTaskHandler struct {
-	reqClient   api.RequestClient
+	reqClient   requestClient
 	confManager config.ConfManager
 	errChan     chan error
 	pubSub      *gochannel.GoChannel
 
 	// Master-slave components (optional)
 	slaveRegistry *master.SlaveRegistry
-	masterClient  *master.Client
+	masterClient  slaveFileRequester
 	masterConfig  *config.MasterConfig
 }
 
 func NewTaskHandler(reqClient api.RequestClient, confManager config.ConfManager, pubSub *gochannel.GoChannel, errChan chan error) *CustomTaskHandler {
 	return &CustomTaskHandler{
-		reqClient:   reqClient,
+		reqClient:   &reqClient,
 		confManager: confManager,
 		errChan:     errChan,
 		pubSub:      pubSub,
@@ -86,27 +98,22 @@ func (c *CustomTaskHandler) run(_ context.Context) {
 		return
 	}
 
-	//nolint: contextcheck // context is checked in the parent goroutine
 	cancellingUploadTasks, err := c.reqClient.ListDeviceTasks(deviceInfo.GetName(), enums.TaskStateEnum_CANCELLING.Enum(), enums.TaskCategoryEnum_UPLOAD.String())
 	if err != nil {
 		log.Errorf("Failed to list device cancelling upload tasks: %v", err)
 		c.errChan <- err
 		return
 	}
-	//nolint: contextcheck // context is checked in the parent goroutine
 	c.handleCancellingTasks(cancellingUploadTasks)
 
-	//nolint: contextcheck // context is checked in the parent goroutine
 	cancellingDiagnosisTasks, err := c.reqClient.ListDeviceTasks(deviceInfo.GetName(), enums.TaskStateEnum_CANCELLING.Enum(), enums.TaskCategoryEnum_DIAGNOSIS.String())
 	if err != nil {
 		log.Errorf("Failed to list device cancelling diagnosis tasks: %v", err)
 		c.errChan <- err
 		return
 	}
-	//nolint: contextcheck // context is checked in the parent goroutine
 	c.handleCancellingTasks(cancellingDiagnosisTasks)
 
-	//nolint: contextcheck // context is checked in the parent goroutine
 	pendingTasks, err := c.reqClient.ListDeviceTasks(deviceInfo.GetName(), enums.TaskStateEnum_PENDING.Enum(), enums.TaskCategoryEnum_UPLOAD.String())
 	if err != nil {
 		log.Errorf("Failed to list device tasks: %v", err)
@@ -200,13 +207,23 @@ func (c *CustomTaskHandler) handlePendingTasks(tasks []*openDpsV1alpha1Resource.
 			continue
 		}
 
-		log.WithField("taskName", task.GetName()).Infof("Starting handle upload task")
-		_, err := c.reqClient.UpdateTaskState(task.GetName(), enums.TaskStateEnum_PROCESSING.Enum())
-		if err != nil {
-			log.WithField("taskName", task.GetName()).Errorf("Failed to update task state: %v", err)
-			continue
+		taskDetail := task.GetUploadTaskDetail()
+		if taskDetail != nil {
+			err := upload.ValidateTimeWindow(taskDetail.GetStartTime().AsTime().Unix(), taskDetail.GetEndTime().AsTime().Unix())
+			switch {
+			case errors.Is(err, upload.ErrTimeWindowNotReady):
+				log.WithField("taskName", task.GetName()).Infof("Upload task is not ready yet, keeping it pending: %v", err)
+				continue
+			case errors.Is(err, upload.ErrInvalidTimeWindow):
+				log.WithField("taskName", task.GetName()).Errorf("Upload task has a permanently invalid time window: %v", err)
+				if _, updateErr := c.reqClient.UpdateTaskState(task.GetName(), enums.TaskStateEnum_FAILED.Enum()); updateErr != nil {
+					log.WithField("taskName", task.GetName()).Errorf("Failed to mark invalid upload task failed: %v", updateErr)
+				}
+				continue
+			}
 		}
 
+		log.WithField("taskName", task.GetName()).Infof("Starting handle upload task")
 		if task.GetUploadTaskDetail() != nil {
 			c.handleUploadTask(task)
 		} else {
@@ -235,7 +252,11 @@ func (c *CustomTaskHandler) handleUploadTask(task *openDpsV1alpha1Resource.Task)
 			startTime.AsTime().String(), endTime.AsTime().String(), taskFolders, additionalFiles)
 
 	// Get local files
-	localFiles, noPermissionFolders := upload.ComputeUploadFiles(task.GetName(), taskFolders, additionalFiles, []string{}, true, startTime.AsTime().Unix(), endTime.AsTime().Unix())
+	localFiles, noPermissionFolders, err := upload.ComputeUploadFiles(task.GetName(), taskFolders, additionalFiles, []string{}, true, startTime.AsTime().Unix(), endTime.AsTime().Unix())
+	if err != nil {
+		log.WithField("taskName", task.GetName()).Errorf("Upload task scan did not run: %v", err)
+		return
+	}
 
 	// Get slave files if master-slave is enabled
 	allFiles := make(map[string]model.FileInfo)
@@ -257,6 +278,17 @@ func (c *CustomTaskHandler) handleUploadTask(task *openDpsV1alpha1Resource.Task)
 		}
 
 		responses := c.masterClient.RequestAllSlaveFiles(ctx, c.slaveRegistry, taskReq)
+		switch master.TaskResponsesTimeWindowErrorCode(responses) {
+		case master.TaskErrorCodeInvalidTimeWindow:
+			log.WithField("taskName", task.GetName()).Error("A slave rejected the upload task's time window as permanently invalid")
+			if _, err := c.reqClient.UpdateTaskState(task.GetName(), enums.TaskStateEnum_FAILED.Enum()); err != nil {
+				log.WithField("taskName", task.GetName()).Errorf("Failed to mark upload task failed: %v", err)
+			}
+			return
+		case master.TaskErrorCodeTimeWindowNotReady:
+			log.WithField("taskName", task.GetName()).Info("A slave is not ready for the upload time window, keeping task pending")
+			return
+		}
 		for slaveID, response := range responses {
 			if response != nil && response.Success {
 				log.WithField("taskName", task.GetName()).Infof("Slave %s returned %d files", slaveID, len(response.Files))
@@ -272,6 +304,10 @@ func (c *CustomTaskHandler) handleUploadTask(task *openDpsV1alpha1Resource.Task)
 				}
 			}
 		}
+	}
+	if _, err := c.reqClient.UpdateTaskState(task.GetName(), enums.TaskStateEnum_PROCESSING.Enum()); err != nil {
+		log.WithField("taskName", task.GetName()).Errorf("Failed to update task state: %v", err)
+		return
 	}
 	log.WithField("taskName", task.GetName()).Infof("Total files: %d (local: %d, slave: %d)", len(allFiles), len(localFiles), slaveFileCount)
 	if len(allFiles) == 0 {
@@ -306,7 +342,7 @@ func (c *CustomTaskHandler) handleUploadTask(task *openDpsV1alpha1Resource.Task)
 		},
 		OriginalFiles: allFiles,
 	}
-	err := rc.Save()
+	err = rc.Save()
 	if err != nil {
 		log.Errorf("Failed to save record cache: %v", err)
 		return

--- a/internal/mod/task/handler_test.go
+++ b/internal/mod/task/handler_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
+	"buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"github.com/coscene-io/coscout/internal/config"
+	"github.com/coscene-io/coscout/internal/master"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestHandlePendingTasksKeepsFutureWindowPending(t *testing.T) {
+	t.Parallel()
+
+	client := &recordingRequestClient{}
+	handler := &CustomTaskHandler{reqClient: client}
+	now := time.Now()
+	handler.handlePendingTasks([]*resources.Task{
+		uploadTaskForWindow("future", now.Add(10*time.Minute), now.Add(20*time.Minute)),
+	})
+
+	if len(client.stateUpdates) != 0 {
+		t.Fatalf("state updates = %v, want none so the task remains pending", client.stateUpdates)
+	}
+}
+
+func TestHandlePendingTasksMarksInvalidWindowFailed(t *testing.T) {
+	t.Parallel()
+
+	client := &recordingRequestClient{}
+	handler := &CustomTaskHandler{reqClient: client}
+	now := time.Now()
+	handler.handlePendingTasks([]*resources.Task{
+		uploadTaskForWindow("invalid", now, now.Add(-time.Minute)),
+	})
+
+	if len(client.stateUpdates) != 1 {
+		t.Fatalf("state updates = %v, want one permanent failure", client.stateUpdates)
+	}
+	if got := client.stateUpdates[0]; got != enums.TaskStateEnum_FAILED {
+		t.Fatalf("state update = %v, want FAILED", got)
+	}
+}
+
+func TestHandlePendingTasksKeepsTaskPendingWhenSlaveIsNotReady(t *testing.T) {
+	t.Parallel()
+
+	client := &recordingRequestClient{}
+	handler := &CustomTaskHandler{
+		reqClient:     client,
+		slaveRegistry: master.NewSlaveRegistry(),
+		masterClient: &recordingSlaveFileRequester{
+			responses: map[string]*master.TaskResponse{
+				"slow-clock": {
+					Success:   false,
+					ErrorCode: master.TaskErrorCodeTimeWindowNotReady,
+				},
+			},
+		},
+		masterConfig: &config.MasterConfig{RequestTimeout: time.Second},
+	}
+	now := time.Now()
+	handler.handlePendingTasks([]*resources.Task{
+		uploadTaskForWindow("slave-future", now.Add(4*time.Minute), now.Add(10*time.Minute)),
+	})
+
+	if len(client.stateUpdates) != 0 {
+		t.Fatalf("state updates = %v, want none so the task remains pending", client.stateUpdates)
+	}
+}
+
+func TestHandlePendingTasksMarksFailedWhenAnySlaveWindowIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	client := &recordingRequestClient{}
+	handler := &CustomTaskHandler{
+		reqClient:     client,
+		slaveRegistry: master.NewSlaveRegistry(),
+		masterClient: &recordingSlaveFileRequester{
+			responses: map[string]*master.TaskResponse{
+				"slow-clock": {
+					Success:   false,
+					ErrorCode: master.TaskErrorCodeTimeWindowNotReady,
+				},
+				"invalid": {
+					Success:   false,
+					ErrorCode: master.TaskErrorCodeInvalidTimeWindow,
+				},
+			},
+		},
+		masterConfig: &config.MasterConfig{RequestTimeout: time.Second},
+	}
+	now := time.Now()
+	handler.handlePendingTasks([]*resources.Task{
+		uploadTaskForWindow("slave-invalid", now.Add(-time.Minute), now.Add(time.Minute)),
+	})
+
+	if len(client.stateUpdates) != 1 || client.stateUpdates[0] != enums.TaskStateEnum_FAILED {
+		t.Fatalf("state updates = %v, want [FAILED]", client.stateUpdates)
+	}
+}
+
+func TestHandlePendingTasksStillProcessesRunnableWindow(t *testing.T) {
+	t.Parallel()
+
+	client := &recordingRequestClient{}
+	handler := &CustomTaskHandler{reqClient: client}
+	now := time.Now()
+	handler.handlePendingTasks([]*resources.Task{
+		uploadTaskForWindow("runnable", now.Add(-time.Minute), now),
+	})
+
+	if len(client.stateUpdates) != 2 {
+		t.Fatalf("state updates = %v, want PROCESSING then SUCCEEDED", client.stateUpdates)
+	}
+	if client.stateUpdates[0] != enums.TaskStateEnum_PROCESSING ||
+		client.stateUpdates[1] != enums.TaskStateEnum_SUCCEEDED {
+		t.Fatalf("state updates = %v, want [PROCESSING SUCCEEDED]", client.stateUpdates)
+	}
+}
+
+type recordingRequestClient struct {
+	stateUpdates []enums.TaskStateEnum_TaskState
+}
+
+func (c *recordingRequestClient) ListDeviceTasks(string, *enums.TaskStateEnum_TaskState, string) ([]*resources.Task, error) {
+	return nil, nil
+}
+
+func (c *recordingRequestClient) UpdateTaskState(_ string, state *enums.TaskStateEnum_TaskState) (*resources.Task, error) {
+	c.stateUpdates = append(c.stateUpdates, *state)
+	return &resources.Task{}, nil
+}
+
+func (c *recordingRequestClient) AddTaskTags(string, map[string]string) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+type recordingSlaveFileRequester struct {
+	responses map[string]*master.TaskResponse
+}
+
+func (r *recordingSlaveFileRequester) RequestAllSlaveFiles(context.Context, *master.SlaveRegistry, *master.TaskRequest) map[string]*master.TaskResponse {
+	return r.responses
+}
+
+func uploadTaskForWindow(name string, start, end time.Time) *resources.Task {
+	return &resources.Task{
+		Name: "projects/test/tasks/" + name,
+		Detail: &resources.Task_UploadTaskDetail{
+			UploadTaskDetail: &resources.UploadTaskDetail{
+				StartTime:   timestamppb.New(start),
+				EndTime:     timestamppb.New(end),
+				ScanFolders: []string{"/must-not-be-accessed"},
+			},
+		},
+	}
+}

--- a/internal/mod/task/handler_test.go
+++ b/internal/mod/task/handler_test.go
@@ -27,18 +27,32 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestHandlePendingTasksKeepsFutureWindowPending(t *testing.T) {
+func TestHandlePendingTasksCompletesFutureWindowAsEmptySuccess(t *testing.T) {
 	t.Parallel()
 
 	client := &recordingRequestClient{}
-	handler := &CustomTaskHandler{reqClient: client}
+	slaveRequester := &recordingSlaveFileRequester{}
+	handler := &CustomTaskHandler{
+		reqClient:     client,
+		slaveRegistry: master.NewSlaveRegistry(),
+		masterClient:  slaveRequester,
+		masterConfig:  &config.MasterConfig{RequestTimeout: time.Second},
+	}
 	now := time.Now()
 	handler.handlePendingTasks([]*resources.Task{
 		uploadTaskForWindow("future", now.Add(10*time.Minute), now.Add(20*time.Minute)),
 	})
 
-	if len(client.stateUpdates) != 0 {
-		t.Fatalf("state updates = %v, want none so the task remains pending", client.stateUpdates)
+	if len(client.stateUpdates) != 2 ||
+		client.stateUpdates[0] != enums.TaskStateEnum_PROCESSING ||
+		client.stateUpdates[1] != enums.TaskStateEnum_SUCCEEDED {
+		t.Fatalf("state updates = %v, want [PROCESSING SUCCEEDED]", client.stateUpdates)
+	}
+	if client.tagUpdates != 0 {
+		t.Fatalf("tag updates = %d, want 0 because future-start handling must not inspect scan paths", client.tagUpdates)
+	}
+	if slaveRequester.requests != 0 {
+		t.Fatalf("slave requests = %d, want 0 because future-start handling must finish locally", slaveRequester.requests)
 	}
 }
 
@@ -60,30 +74,36 @@ func TestHandlePendingTasksMarksInvalidWindowFailed(t *testing.T) {
 	}
 }
 
-func TestHandlePendingTasksKeepsTaskPendingWhenSlaveIsNotReady(t *testing.T) {
+func TestHandlePendingTasksTreatsLegacySlaveNotReadyAsEmptySuccess(t *testing.T) {
 	t.Parallel()
 
 	client := &recordingRequestClient{}
+	slaveRequester := &recordingSlaveFileRequester{
+		responses: map[string]*master.TaskResponse{
+			"slow-clock": {
+				Success:   false,
+				ErrorCode: master.TaskErrorCodeTimeWindowNotReady,
+			},
+		},
+	}
 	handler := &CustomTaskHandler{
 		reqClient:     client,
 		slaveRegistry: master.NewSlaveRegistry(),
-		masterClient: &recordingSlaveFileRequester{
-			responses: map[string]*master.TaskResponse{
-				"slow-clock": {
-					Success:   false,
-					ErrorCode: master.TaskErrorCodeTimeWindowNotReady,
-				},
-			},
-		},
-		masterConfig: &config.MasterConfig{RequestTimeout: time.Second},
+		masterClient:  slaveRequester,
+		masterConfig:  &config.MasterConfig{RequestTimeout: time.Second},
 	}
 	now := time.Now()
-	handler.handlePendingTasks([]*resources.Task{
-		uploadTaskForWindow("slave-future", now.Add(4*time.Minute), now.Add(10*time.Minute)),
-	})
+	task := uploadTaskForWindow("slave-future", now.Add(-time.Minute), now.Add(time.Minute))
+	task.GetUploadTaskDetail().ScanFolders = nil
+	handler.handlePendingTasks([]*resources.Task{task})
 
-	if len(client.stateUpdates) != 0 {
-		t.Fatalf("state updates = %v, want none so the task remains pending", client.stateUpdates)
+	if len(client.stateUpdates) != 2 ||
+		client.stateUpdates[0] != enums.TaskStateEnum_PROCESSING ||
+		client.stateUpdates[1] != enums.TaskStateEnum_SUCCEEDED {
+		t.Fatalf("state updates = %v, want [PROCESSING SUCCEEDED]", client.stateUpdates)
+	}
+	if slaveRequester.requests != 1 {
+		t.Fatalf("slave requests = %d, want 1 for legacy response compatibility", slaveRequester.requests)
 	}
 }
 
@@ -139,6 +159,7 @@ func TestHandlePendingTasksStillProcessesRunnableWindow(t *testing.T) {
 
 type recordingRequestClient struct {
 	stateUpdates []enums.TaskStateEnum_TaskState
+	tagUpdates   int
 }
 
 func (c *recordingRequestClient) ListDeviceTasks(string, *enums.TaskStateEnum_TaskState, string) ([]*resources.Task, error) {
@@ -151,14 +172,17 @@ func (c *recordingRequestClient) UpdateTaskState(_ string, state *enums.TaskStat
 }
 
 func (c *recordingRequestClient) AddTaskTags(string, map[string]string) (*emptypb.Empty, error) {
+	c.tagUpdates++
 	return &emptypb.Empty{}, nil
 }
 
 type recordingSlaveFileRequester struct {
 	responses map[string]*master.TaskResponse
+	requests  int
 }
 
 func (r *recordingSlaveFileRequester) RequestAllSlaveFiles(context.Context, *master.SlaveRegistry, *master.TaskRequest) map[string]*master.TaskResponse {
+	r.requests++
 	return r.responses
 }
 

--- a/internal/slave/server.go
+++ b/internal/slave/server.go
@@ -40,6 +40,9 @@ type Server struct {
 	server     *http.Server
 	port       int
 	filePrefix string
+	// hasBirthTime reports whether the scan roots expose filesystem birth time.
+	// Tests override it to verify that invalid/future windows return before the probe.
+	hasBirthTime func([]string) bool
 	// collectFileStateHandler caches file metadata and content time
 	collectFileStateHandler file_state_handler.FileStateHandler
 }
@@ -56,9 +59,10 @@ func NewServer(port int, filePrefix string) *Server {
 	}
 
 	s := &Server{
-		server:     server,
-		port:       port,
-		filePrefix: filePrefix,
+		server:       server,
+		port:         port,
+		filePrefix:   filePrefix,
+		hasBirthTime: utils.HasBirthTime,
 	}
 
 	// Initialize collect file state handler for content-based scans
@@ -254,11 +258,15 @@ func (s *Server) handleFileScanByContent(w http.ResponseWriter, r *http.Request)
 func (s *Server) scanFilesByContent(taskID string, scanFolders []string, additionalFiles []string, whiteList []string, recursivelyWalkDirs bool, startTime, endTime int64) ([]master.SlaveFileInfo, error) {
 	result := make([]master.SlaveFileInfo, 0)
 	if err := upload.ValidateTimeWindow(startTime, endTime); err != nil {
+		if errors.Is(err, upload.ErrTimeWindowNotReady) {
+			log.WithField("taskName", taskID).Infof("Start time is beyond the future tolerance, returning an empty successful scan: %v", err)
+			return result, nil
+		}
 		return result, err
 	}
 
 	fileStates := make([]file_state_handler.FileState, 0)
-	hasBirthTime := utils.HasBirthTime(scanFolders)
+	hasBirthTime := s.supportsBirthTime(scanFolders)
 	//nolint: nestif // nested if is more readable here.
 	if hasBirthTime {
 		log.WithField("taskName", taskID).Infof("os supports birth time, will use birth time for content time filtering")
@@ -359,6 +367,13 @@ func (s *Server) scanFilesByContent(taskID string, scanFolders []string, additio
 
 	log.Infof("Found %d files matching content time range", len(result))
 	return result, nil
+}
+
+func (s *Server) supportsBirthTime(paths []string) bool {
+	if s.hasBirthTime != nil {
+		return s.hasBirthTime(paths)
+	}
+	return utils.HasBirthTime(paths)
 }
 
 func scanErrorCode(err error) string {

--- a/internal/slave/server.go
+++ b/internal/slave/server.go
@@ -118,11 +118,15 @@ func (s *Server) handleFileScan(w http.ResponseWriter, r *http.Request) {
 
 	log.Infof("Received file scan request: %+v", req)
 
-	files := s.scanFiles(req.TaskID, req.ScanFolders, req.AdditionalFiles, req.StartTime, req.EndTime)
+	files, err := s.scanFiles(req.TaskID, req.ScanFolders, req.AdditionalFiles, req.StartTime, req.EndTime)
 	resp := master.TaskResponse{
 		TaskID:  req.TaskID,
 		Files:   files,
-		Success: true,
+		Success: err == nil,
+	}
+	if err != nil {
+		resp.ErrorCode = scanErrorCode(err)
+		resp.Error = err.Error()
 	}
 
 	s.writeJSON(w, resp)
@@ -190,8 +194,11 @@ func (s *Server) handleFileDownload(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) scanFiles(taskID string, scanFolders []string, additionalFiles []string, startTime, endTime int64) []master.SlaveFileInfo {
-	files, noPermissionFiles := upload.ComputeUploadFiles(taskID, scanFolders, additionalFiles, []string{}, true, startTime, endTime)
+func (s *Server) scanFiles(taskID string, scanFolders []string, additionalFiles []string, startTime, endTime int64) ([]master.SlaveFileInfo, error) {
+	files, noPermissionFiles, err := upload.ComputeUploadFiles(taskID, scanFolders, additionalFiles, []string{}, true, startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
 	if len(noPermissionFiles) > 0 {
 		log.WithField("taskName", taskID).Warnf("Some files/folders are not readable: %v", noPermissionFiles)
 	}
@@ -204,7 +211,7 @@ func (s *Server) scanFiles(taskID string, scanFolders []string, additionalFiles 
 		}
 		result = append(result, info)
 	}
-	return result
+	return result, nil
 }
 
 func (s *Server) writeJSON(w http.ResponseWriter, data interface{}) {
@@ -229,26 +236,36 @@ func (s *Server) handleFileScanByContent(w http.ResponseWriter, r *http.Request)
 	}
 
 	log.Infof("Received file scan by content request: %+v", req)
-	files := s.scanFilesByContent(req.TaskID, req.ScanFolders, req.AdditionalFiles, req.WhiteList, req.RecursivelyWalkDirs, req.StartTime, req.EndTime)
+	files, err := s.scanFilesByContent(req.TaskID, req.ScanFolders, req.AdditionalFiles, req.WhiteList, req.RecursivelyWalkDirs, req.StartTime, req.EndTime)
 	resp := master.TaskResponse{
 		TaskID:  req.TaskID,
 		Files:   files,
-		Success: true,
+		Success: err == nil,
+	}
+	if err != nil {
+		resp.ErrorCode = scanErrorCode(err)
+		resp.Error = err.Error()
 	}
 
 	s.writeJSON(w, resp)
 }
 
 // scanFilesByContent scans files based on their content time rather than modification time.
-func (s *Server) scanFilesByContent(taskID string, scanFolders []string, additionalFiles []string, whiteList []string, recursivelyWalkDirs bool, startTime, endTime int64) []master.SlaveFileInfo {
+func (s *Server) scanFilesByContent(taskID string, scanFolders []string, additionalFiles []string, whiteList []string, recursivelyWalkDirs bool, startTime, endTime int64) ([]master.SlaveFileInfo, error) {
 	result := make([]master.SlaveFileInfo, 0)
+	if err := upload.ValidateTimeWindow(startTime, endTime); err != nil {
+		return result, err
+	}
 
 	fileStates := make([]file_state_handler.FileState, 0)
 	hasBirthTime := utils.HasBirthTime(scanFolders)
 	//nolint: nestif // nested if is more readable here.
 	if hasBirthTime {
 		log.WithField("taskName", taskID).Infof("os supports birth time, will use birth time for content time filtering")
-		files, noPermissionFiles := upload.ComputeUploadFiles(taskID, scanFolders, additionalFiles, whiteList, recursivelyWalkDirs, startTime, endTime)
+		files, noPermissionFiles, err := upload.ComputeUploadFiles(taskID, scanFolders, additionalFiles, whiteList, recursivelyWalkDirs, startTime, endTime)
+		if err != nil {
+			return result, err
+		}
 		if len(noPermissionFiles) > 0 {
 			log.WithField("taskName", taskID).Warnf("Some files/folders are not readable: %v", noPermissionFiles)
 		}
@@ -265,7 +282,7 @@ func (s *Server) scanFilesByContent(taskID string, scanFolders []string, additio
 
 		if s.collectFileStateHandler == nil {
 			log.WithField("taskName", taskID).Errorf("collect file state handler is nil")
-			return result
+			return result, nil
 		}
 
 		// Update cache via file_state_handler using provided scan folders
@@ -275,7 +292,7 @@ func (s *Server) scanFilesByContent(taskID string, scanFolders []string, additio
 		}
 		if err := s.collectFileStateHandler.UpdateCollectDirs(whiteList, conf); err != nil {
 			log.Errorf("file state handler update collect dirs: %v", err)
-			return result
+			return result, nil
 		}
 
 		// Build filters: collecting + time overlap
@@ -341,5 +358,16 @@ func (s *Server) scanFilesByContent(taskID string, scanFolders []string, additio
 	}
 
 	log.Infof("Found %d files matching content time range", len(result))
-	return result
+	return result, nil
+}
+
+func scanErrorCode(err error) string {
+	switch {
+	case errors.Is(err, upload.ErrInvalidTimeWindow):
+		return master.TaskErrorCodeInvalidTimeWindow
+	case errors.Is(err, upload.ErrTimeWindowNotReady):
+		return master.TaskErrorCodeTimeWindowNotReady
+	default:
+		return ""
+	}
 }

--- a/internal/slave/server_test.go
+++ b/internal/slave/server_test.go
@@ -42,12 +42,39 @@ func TestScanFilesRejectsInvalidWindowBeforeFilesystemAccess(t *testing.T) {
 	}
 }
 
-func TestScanFilesByContentDefersFutureWindowBeforeFilesystemAccess(t *testing.T) {
+func TestScanFilesReturnsEmptySuccessForFutureWindowBeforeFilesystemAccess(t *testing.T) {
 	t.Parallel()
 
 	missingPath := filepath.Join(t.TempDir(), "must-not-be-accessed")
 	now := time.Now()
-	files, err := (&Server{}).scanFilesByContent(
+	files, err := (&Server{}).scanFiles(
+		"future",
+		[]string{missingPath},
+		[]string{missingPath},
+		now.Add(10*time.Minute).Unix(),
+		now.Add(20*time.Minute).Unix(),
+	)
+
+	if err != nil {
+		t.Fatalf("error = %v, want empty success", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("files = %v, want none", files)
+	}
+}
+
+func TestScanFilesByContentReturnsEmptySuccessForFutureWindowBeforeFilesystemAccess(t *testing.T) {
+	t.Parallel()
+
+	missingPath := filepath.Join(t.TempDir(), "must-not-be-accessed")
+	now := time.Now()
+	server := &Server{
+		hasBirthTime: func([]string) bool {
+			t.Fatal("birth-time probe was called for a future window")
+			return false
+		},
+	}
+	files, err := server.scanFilesByContent(
 		"future",
 		[]string{missingPath},
 		[]string{missingPath},
@@ -57,15 +84,43 @@ func TestScanFilesByContentDefersFutureWindowBeforeFilesystemAccess(t *testing.T
 		now.Add(20*time.Minute).Unix(),
 	)
 
-	if !errors.Is(err, upload.ErrTimeWindowNotReady) {
-		t.Fatalf("error = %v, want ErrTimeWindowNotReady", err)
+	if err != nil {
+		t.Fatalf("error = %v, want empty success", err)
 	}
 	if len(files) != 0 {
 		t.Fatalf("files = %v, want none", files)
 	}
 }
 
-func TestFileScanHandlersReturnRecognizableTimeWindowStatus(t *testing.T) {
+func TestScanFilesByContentRejectsInvalidWindowBeforeFilesystemAccess(t *testing.T) {
+	t.Parallel()
+
+	missingPath := filepath.Join(t.TempDir(), "must-not-be-accessed")
+	server := &Server{
+		hasBirthTime: func([]string) bool {
+			t.Fatal("birth-time probe was called for an invalid window")
+			return false
+		},
+	}
+	files, err := server.scanFilesByContent(
+		"invalid",
+		[]string{missingPath},
+		[]string{missingPath},
+		nil,
+		true,
+		2,
+		1,
+	)
+
+	if !errors.Is(err, upload.ErrInvalidTimeWindow) {
+		t.Fatalf("error = %v, want ErrInvalidTimeWindow", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("files = %v, want none", files)
+	}
+}
+
+func TestFileScanHandlersReturnTimeWindowOutcomes(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
@@ -74,6 +129,7 @@ func TestFileScanHandlersReturnRecognizableTimeWindowStatus(t *testing.T) {
 		handler       func(http.ResponseWriter, *http.Request)
 		startTime     int64
 		endTime       int64
+		wantSuccess   bool
 		wantErrorCode string
 	}{
 		{
@@ -84,11 +140,25 @@ func TestFileScanHandlersReturnRecognizableTimeWindowStatus(t *testing.T) {
 			wantErrorCode: master.TaskErrorCodeInvalidTimeWindow,
 		},
 		{
-			name:          "future window",
+			name:          "invalid window by content time",
 			handler:       (&Server{}).handleFileScanByContent,
-			startTime:     now.Add(10 * time.Minute).Unix(),
-			endTime:       now.Add(20 * time.Minute).Unix(),
-			wantErrorCode: master.TaskErrorCodeTimeWindowNotReady,
+			startTime:     now.Unix(),
+			endTime:       now.Add(-time.Minute).Unix(),
+			wantErrorCode: master.TaskErrorCodeInvalidTimeWindow,
+		},
+		{
+			name:        "future window by modification time",
+			handler:     (&Server{}).handleFileScan,
+			startTime:   now.Add(10 * time.Minute).Unix(),
+			endTime:     now.Add(20 * time.Minute).Unix(),
+			wantSuccess: true,
+		},
+		{
+			name:        "future window by content time",
+			handler:     (&Server{}).handleFileScanByContent,
+			startTime:   now.Add(10 * time.Minute).Unix(),
+			endTime:     now.Add(20 * time.Minute).Unix(),
+			wantSuccess: true,
 		},
 	}
 
@@ -114,13 +184,16 @@ func TestFileScanHandlersReturnRecognizableTimeWindowStatus(t *testing.T) {
 			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
 				t.Fatalf("decode response: %v", err)
 			}
-			if response.Success {
-				t.Fatalf("response = %+v, want unsuccessful scan", response)
+			if response.Success != tc.wantSuccess {
+				t.Fatalf("success = %v, want %v: %+v", response.Success, tc.wantSuccess, response)
 			}
 			if response.ErrorCode != tc.wantErrorCode {
 				t.Fatalf("error code = %q, want %q", response.ErrorCode, tc.wantErrorCode)
 			}
-			if response.Error == "" {
+			if tc.wantSuccess && (response.Error != "" || len(response.Files) != 0) {
+				t.Fatalf("response = %+v, want successful empty result", response)
+			}
+			if !tc.wantSuccess && response.Error == "" {
 				t.Fatalf("response = %+v, want diagnostic error text", response)
 			}
 		})

--- a/internal/slave/server_test.go
+++ b/internal/slave/server_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slave
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/coscene-io/coscout/internal/master"
+	"github.com/coscene-io/coscout/pkg/upload"
+)
+
+func TestScanFilesRejectsInvalidWindowBeforeFilesystemAccess(t *testing.T) {
+	t.Parallel()
+
+	missingPath := filepath.Join(t.TempDir(), "must-not-be-accessed")
+	files, err := (&Server{}).scanFiles("invalid", []string{missingPath}, []string{missingPath}, 2, 1)
+
+	if !errors.Is(err, upload.ErrInvalidTimeWindow) {
+		t.Fatalf("error = %v, want ErrInvalidTimeWindow", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("files = %v, want none", files)
+	}
+}
+
+func TestScanFilesByContentDefersFutureWindowBeforeFilesystemAccess(t *testing.T) {
+	t.Parallel()
+
+	missingPath := filepath.Join(t.TempDir(), "must-not-be-accessed")
+	now := time.Now()
+	files, err := (&Server{}).scanFilesByContent(
+		"future",
+		[]string{missingPath},
+		[]string{missingPath},
+		nil,
+		true,
+		now.Add(10*time.Minute).Unix(),
+		now.Add(20*time.Minute).Unix(),
+	)
+
+	if !errors.Is(err, upload.ErrTimeWindowNotReady) {
+		t.Fatalf("error = %v, want ErrTimeWindowNotReady", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("files = %v, want none", files)
+	}
+}
+
+func TestFileScanHandlersReturnRecognizableTimeWindowStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	tests := []struct {
+		name          string
+		handler       func(http.ResponseWriter, *http.Request)
+		startTime     int64
+		endTime       int64
+		wantErrorCode string
+	}{
+		{
+			name:          "invalid window",
+			handler:       (&Server{}).handleFileScan,
+			startTime:     now.Unix(),
+			endTime:       now.Add(-time.Minute).Unix(),
+			wantErrorCode: master.TaskErrorCodeInvalidTimeWindow,
+		},
+		{
+			name:          "future window",
+			handler:       (&Server{}).handleFileScanByContent,
+			startTime:     now.Add(10 * time.Minute).Unix(),
+			endTime:       now.Add(20 * time.Minute).Unix(),
+			wantErrorCode: master.TaskErrorCodeTimeWindowNotReady,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var body bytes.Buffer
+			if err := json.NewEncoder(&body).Encode(master.TaskRequest{
+				TaskID:      tc.name,
+				StartTime:   tc.startTime,
+				EndTime:     tc.endTime,
+				ScanFolders: []string{filepath.Join(t.TempDir(), "must-not-be-accessed")},
+			}); err != nil {
+				t.Fatalf("encode request: %v", err)
+			}
+
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPost, "/", &body)
+			tc.handler(recorder, request)
+
+			var response master.TaskResponse
+			if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.Success {
+				t.Fatalf("response = %+v, want unsuccessful scan", response)
+			}
+			if response.ErrorCode != tc.wantErrorCode {
+				t.Fatalf("error code = %q, want %q", response.ErrorCode, tc.wantErrorCode)
+			}
+			if response.Error == "" {
+				t.Fatalf("response = %+v, want diagnostic error text", response)
+			}
+		})
+	}
+}

--- a/pkg/upload/file.go
+++ b/pkg/upload/file.go
@@ -32,9 +32,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func ComputeUploadFiles(taskName string, scanFolders []string, additionalFiles []string, whiteList []string, recursivelyWalkDirs bool, startTime int64, endTime int64) (map[string]model.FileInfo, []string) {
+func ComputeUploadFiles(taskName string, scanFolders []string, additionalFiles []string, whiteList []string, recursivelyWalkDirs bool, startTime int64, endTime int64) (map[string]model.FileInfo, []string, error) {
 	files := make(map[string]model.FileInfo)
 	noPermissionFolders := make([]string, 0)
+	if err := ValidateTimeWindow(startTime, endTime); err != nil {
+		return files, noPermissionFolders, err
+	}
 
 	matchesWhitelist := func(filename string) bool {
 		if len(whiteList) == 0 {
@@ -82,7 +85,7 @@ func ComputeUploadFiles(taskName string, scanFolders []string, additionalFiles [
 			continue
 		}
 
-		processFile := func(root, filePath string, info os.FileInfo) {
+		processFile := func(target map[string]model.FileInfo, root, filePath string, info os.FileInfo) {
 			if !matchesWhitelist(filePath) {
 				log.WithField("taskName", taskName).Warnf("file path %s does not match whitelist, skip!", filePath)
 				return
@@ -107,7 +110,7 @@ func ComputeUploadFiles(taskName string, scanFolders []string, additionalFiles [
 					filename = filepath.Base(filePath)
 				}
 
-				files[filePath] = model.FileInfo{
+				target[filePath] = model.FileInfo{
 					FileName: filename,
 					Size:     info.Size(),
 					Path:     filePath,
@@ -122,39 +125,42 @@ func ComputeUploadFiles(taskName string, scanFolders []string, additionalFiles [
 		rootDir := realPath
 		//nolint: nestif // nested if is acceptable here for clarity.
 		if recursivelyWalkDirs {
-			filePaths, err := utils.GetAllFilePaths(rootDir, &utils.SymWalkOptions{
+			folderFiles := make(map[string]model.FileInfo)
+			err := utils.WalkFilePaths(rootDir, &utils.SymWalkOptions{
 				FollowSymlinks:       true,
 				SkipPermissionErrors: true,
 				SkipEmptyFiles:       true,
 				MaxFiles:             99999,
-			})
-			if err != nil {
-				log.WithField("taskName", taskName).Errorf("Failed to get all file paths in folder %s: %v", folder, err)
-				continue
-			}
-
-			for _, tmpFilePath := range filePaths {
+			}, func(tmpFilePath string) error {
 				if !utils.CheckReadPath(tmpFilePath) {
 					log.WithField("taskName", taskName).Warnf("Path %s is not readable, skip!", tmpFilePath)
-					continue
+					return nil
 				}
 
 				fileAbs, info, err := utils.GetRealFileInfo(tmpFilePath)
 				if err != nil {
 					log.WithField("taskName", taskName).Errorf("Failed to get file info for %s: %v", tmpFilePath, err)
-					continue
+					return nil
 				}
 
 				if !utils.CheckReadPath(fileAbs) {
 					log.WithField("taskName", taskName).Warnf("Path %s is not readable, skip!", fileAbs)
-					continue
+					return nil
 				}
 
 				if info.IsDir() {
-					continue
+					return nil
 				}
 
-				processFile(rootDir, fileAbs, info)
+				processFile(folderFiles, rootDir, fileAbs, info)
+				return nil
+			})
+			if err != nil {
+				log.WithField("taskName", taskName).Errorf("Failed to walk files in folder %s: %v", folder, err)
+				continue
+			}
+			for filePath, fileInfo := range folderFiles {
+				files[filePath] = fileInfo
 			}
 		} else {
 			entries, err := os.ReadDir(rootDir)
@@ -179,7 +185,7 @@ func ComputeUploadFiles(taskName string, scanFolders []string, additionalFiles [
 					continue
 				}
 
-				processFile(realPath, joined, info)
+				processFile(files, realPath, joined, info)
 			}
 		}
 	}
@@ -217,32 +223,27 @@ func ComputeUploadFiles(taskName string, scanFolders []string, additionalFiles [
 		// Clean the file path to handle trailing slashes correctly
 		cleanFile := filepath.Clean(realPath)
 		parentFolder := filepath.Dir(cleanFile)
-		filePaths, err := utils.GetAllFilePaths(realPath, &utils.SymWalkOptions{
+		additionalFolderFiles := make(map[string]model.FileInfo)
+		err = utils.WalkFilePaths(realPath, &utils.SymWalkOptions{
 			FollowSymlinks:       true,
 			SkipPermissionErrors: true,
 			SkipEmptyFiles:       true,
 			MaxFiles:             99999,
-		})
-		if err != nil {
-			log.WithField("taskName", taskName).Errorf("AdditionalFiles Failed to walk through folder %s: %v", realPath, err)
-			continue
-		}
-
-		for _, tmpAddFilePath := range filePaths {
+		}, func(tmpAddFilePath string) error {
 			if !utils.CheckReadPath(tmpAddFilePath) {
 				log.WithField("taskName", taskName).Warnf("AdditionalFiles Path %s is not readable, skip!", tmpAddFilePath)
-				continue
+				return nil
 			}
 
 			realPath, info, err := utils.GetRealFileInfo(tmpAddFilePath)
 			if err != nil {
 				log.WithField("taskName", taskName).Errorf("AdditionalFiles Failed to get file info for %s: %v", tmpAddFilePath, err)
-				continue
+				return nil
 			}
 
 			if !utils.CheckReadPath(realPath) {
 				log.WithField("taskName", taskName).Warnf("AdditionalFiles Path %s is not readable, skip!", realPath)
-				continue
+				return nil
 			}
 
 			filename, err := filepath.Rel(parentFolder, realPath)
@@ -251,15 +252,23 @@ func ComputeUploadFiles(taskName string, scanFolders []string, additionalFiles [
 				filename = filepath.Base(realPath)
 			}
 
-			files[realPath] = model.FileInfo{
+			additionalFolderFiles[realPath] = model.FileInfo{
 				FileName: filename,
 				Size:     info.Size(),
 				Path:     realPath,
 			}
+			return nil
+		})
+		if err != nil {
+			log.WithField("taskName", taskName).Errorf("AdditionalFiles Failed to walk through folder %s: %v", realPath, err)
+			continue
+		}
+		for filePath, fileInfo := range additionalFolderFiles {
+			files[filePath] = fileInfo
 		}
 	}
 
-	return files, noPermissionFolders
+	return files, noPermissionFolders, nil
 }
 
 func ComputeRuleFileInfos(fileStates []file_state_handler.FileState) map[string]model.FileInfo {
@@ -298,26 +307,21 @@ func ComputeRuleFileInfos(fileStates []file_state_handler.FileState) map[string]
 			continue
 		}
 		baseDir := filepath.Dir(realPath)
-		filePaths, err := utils.GetAllFilePaths(realPath, &utils.SymWalkOptions{
+		directoryFiles := make(map[string]model.FileInfo)
+		err = utils.WalkFilePaths(realPath, &utils.SymWalkOptions{
 			FollowSymlinks:       true,
 			SkipPermissionErrors: true,
 			SkipEmptyFiles:       true,
 			MaxFiles:             99999,
-		})
-		if err != nil {
-			log.Errorf("failed to get all file paths: %v", err)
-			continue
-		}
-
-		for _, filePath := range filePaths {
+		}, func(filePath string) error {
 			realPath, info, err := utils.GetRealFileInfo(filePath)
 			if err != nil {
 				log.Errorf("failed to stat file %s: %v", realPath, err)
-				continue
+				return nil
 			}
 
 			if info.IsDir() {
-				continue
+				return nil
 			}
 
 			filename, err := filepath.Rel(baseDir, realPath)
@@ -326,11 +330,19 @@ func ComputeRuleFileInfos(fileStates []file_state_handler.FileState) map[string]
 				filename = filepath.Base(realPath)
 			}
 
-			files[realPath] = model.FileInfo{
+			directoryFiles[realPath] = model.FileInfo{
 				FileName: filename,
 				Size:     info.Size(),
 				Path:     realPath,
 			}
+			return nil
+		})
+		if err != nil {
+			log.Errorf("failed to walk file paths: %v", err)
+			continue
+		}
+		for filePath, fileInfo := range directoryFiles {
+			files[filePath] = fileInfo
 		}
 	}
 

--- a/pkg/upload/file.go
+++ b/pkg/upload/file.go
@@ -17,6 +17,7 @@ package upload
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -36,6 +37,10 @@ func ComputeUploadFiles(taskName string, scanFolders []string, additionalFiles [
 	files := make(map[string]model.FileInfo)
 	noPermissionFolders := make([]string, 0)
 	if err := ValidateTimeWindow(startTime, endTime); err != nil {
+		if errors.Is(err, ErrTimeWindowNotReady) {
+			log.WithField("taskName", taskName).Infof("Start time is beyond the future tolerance, returning an empty successful scan: %v", err)
+			return files, noPermissionFolders, nil
+		}
 		return files, noPermissionFolders, err
 	}
 

--- a/pkg/upload/file_test.go
+++ b/pkg/upload/file_test.go
@@ -47,7 +47,7 @@ func TestComputeUploadFilesInvalidWindowDoesNotTouchFilesystem(t *testing.T) {
 	}
 }
 
-func TestComputeUploadFilesFutureStartDoesNotTouchFilesystem(t *testing.T) {
+func TestComputeUploadFilesFutureStartReturnsEmptySuccessWithoutFilesystemAccess(t *testing.T) {
 	t.Parallel()
 
 	missingPath := filepath.Join(t.TempDir(), "must-not-be-accessed")
@@ -62,8 +62,8 @@ func TestComputeUploadFilesFutureStartDoesNotTouchFilesystem(t *testing.T) {
 		now.Add(20*time.Minute).Unix(),
 	)
 
-	if !errors.Is(err, ErrTimeWindowNotReady) {
-		t.Fatalf("error = %v, want ErrTimeWindowNotReady", err)
+	if err != nil {
+		t.Fatalf("error = %v, want empty success", err)
 	}
 	if len(files) != 0 {
 		t.Fatalf("files = %v, want none", files)

--- a/pkg/upload/file_test.go
+++ b/pkg/upload/file_test.go
@@ -1,0 +1,268 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestComputeUploadFilesInvalidWindowDoesNotTouchFilesystem(t *testing.T) {
+	t.Parallel()
+
+	missingPath := filepath.Join(t.TempDir(), "must-not-be-accessed")
+	files, noPermissionPaths, err := ComputeUploadFiles(
+		"invalid-window",
+		[]string{missingPath},
+		[]string{missingPath},
+		nil,
+		true,
+		200,
+		100,
+	)
+
+	if !errors.Is(err, ErrInvalidTimeWindow) {
+		t.Fatalf("error = %v, want ErrInvalidTimeWindow", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("files = %v, want none", files)
+	}
+	if len(noPermissionPaths) != 0 {
+		t.Fatalf("no-permission paths = %v, want none because validation must precede filesystem access", noPermissionPaths)
+	}
+}
+
+func TestComputeUploadFilesFutureStartDoesNotTouchFilesystem(t *testing.T) {
+	t.Parallel()
+
+	missingPath := filepath.Join(t.TempDir(), "must-not-be-accessed")
+	now := time.Now()
+	files, noPermissionPaths, err := ComputeUploadFiles(
+		"future-window",
+		[]string{missingPath},
+		[]string{missingPath},
+		nil,
+		true,
+		now.Add(10*time.Minute).Unix(),
+		now.Add(20*time.Minute).Unix(),
+	)
+
+	if !errors.Is(err, ErrTimeWindowNotReady) {
+		t.Fatalf("error = %v, want ErrTimeWindowNotReady", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("files = %v, want none", files)
+	}
+	if len(noPermissionPaths) != 0 {
+		t.Fatalf("no-permission paths = %v, want none because validation must precede filesystem access", noPermissionPaths)
+	}
+}
+
+func TestComputeUploadFilesFutureEndStillSelectsCurrentFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	filePath := writeUploadTestFile(t, root, "current.log")
+	now := time.Now()
+	if err := os.Chtimes(filePath, now, now); err != nil {
+		t.Fatalf("set file times: %v", err)
+	}
+
+	files, noPermissionPaths, err := ComputeUploadFiles(
+		"future-end",
+		[]string{root},
+		nil,
+		[]string{"**/*.log"},
+		true,
+		now.Add(-time.Minute).Unix(),
+		now.Add(time.Hour).Unix(),
+	)
+
+	if err != nil {
+		t.Fatalf("ComputeUploadFiles() error = %v", err)
+	}
+	if len(noPermissionPaths) != 0 {
+		t.Fatalf("no-permission paths = %v, want none", noPermissionPaths)
+	}
+	if _, ok := files[filePath]; !ok {
+		t.Fatalf("files = %v, want current file %s selected when end is in the future", files, filePath)
+	}
+}
+
+func TestComputeUploadFilesCharacterizesRecursiveWhitelistSymlinkAndAdditionalFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	nestedDir := filepath.Join(root, "nested")
+	if err := os.Mkdir(nestedDir, 0o755); err != nil {
+		t.Fatalf("create nested dir: %v", err)
+	}
+	matchedPath := writeUploadTestFile(t, nestedDir, "matched.log")
+	_ = writeUploadTestFile(t, nestedDir, "ignored.txt")
+
+	externalDir := t.TempDir()
+	externalPath := writeUploadTestFile(t, externalDir, "linked.log")
+	symlinkPath := filepath.Join(root, "linked.log")
+	if err := os.Symlink(externalPath, symlinkPath); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	externalPath, err := filepath.EvalSymlinks(externalPath)
+	if err != nil {
+		t.Fatalf("resolve external file: %v", err)
+	}
+
+	additionalDir := t.TempDir()
+	additionalPath := writeUploadTestFile(t, additionalDir, "always.bin")
+
+	now := time.Now()
+	files, noPermissionPaths, err := ComputeUploadFiles(
+		"characterization",
+		[]string{root},
+		[]string{additionalDir},
+		[]string{"**/*.log"},
+		true,
+		now.Add(-time.Hour).Unix(),
+		now.Add(time.Hour).Unix(),
+	)
+
+	if err != nil {
+		t.Fatalf("ComputeUploadFiles() error = %v", err)
+	}
+	if len(noPermissionPaths) != 0 {
+		t.Fatalf("no-permission paths = %v, want none", noPermissionPaths)
+	}
+	for _, expected := range []string{matchedPath, externalPath, additionalPath} {
+		if _, ok := files[expected]; !ok {
+			t.Errorf("files = %v, missing %s", files, expected)
+		}
+	}
+	if got, want := len(files), 3; got != want {
+		t.Fatalf("len(files) = %d, want %d: %v", got, want, files)
+	}
+}
+
+func TestComputeUploadFilesCharacterizesNonRecursiveScan(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	directPath := writeUploadTestFile(t, root, "direct.log")
+	nestedDir := filepath.Join(root, "nested")
+	if err := os.Mkdir(nestedDir, 0o755); err != nil {
+		t.Fatalf("create nested dir: %v", err)
+	}
+	nestedPath := writeUploadTestFile(t, nestedDir, "nested.log")
+
+	now := time.Now()
+	files, noPermissionPaths, err := ComputeUploadFiles(
+		"non-recursive",
+		[]string{root},
+		nil,
+		[]string{"**/*.log"},
+		false,
+		now.Add(-time.Hour).Unix(),
+		now.Add(time.Hour).Unix(),
+	)
+
+	if err != nil {
+		t.Fatalf("ComputeUploadFiles() error = %v", err)
+	}
+	if len(noPermissionPaths) != 0 {
+		t.Fatalf("no-permission paths = %v, want none", noPermissionPaths)
+	}
+	if _, ok := files[directPath]; !ok {
+		t.Fatalf("files = %v, want direct file %s", files, directPath)
+	}
+	if _, ok := files[nestedPath]; ok {
+		t.Fatalf("files = %v, nested file %s must not be selected", files, nestedPath)
+	}
+}
+
+func TestComputeUploadFilesDiscardsDirectoryResultsAfterTraversalError(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	_ = writeUploadTestFile(t, root, "a-file.log")
+	if err := os.Symlink(filepath.Join(root, "missing-target"), filepath.Join(root, "z-broken-link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	now := time.Now()
+	files, noPermissionPaths, err := ComputeUploadFiles(
+		"traversal-error",
+		[]string{root},
+		nil,
+		nil,
+		true,
+		now.Add(-time.Hour).Unix(),
+		now.Add(time.Hour).Unix(),
+	)
+
+	if err != nil {
+		t.Fatalf("ComputeUploadFiles() error = %v, want directory traversal errors handled per existing semantics", err)
+	}
+	if len(noPermissionPaths) != 0 {
+		t.Fatalf("no-permission paths = %v, want none", noPermissionPaths)
+	}
+	if len(files) != 0 {
+		t.Fatalf("files = %v, want the failed directory's partial results discarded", files)
+	}
+}
+
+func TestComputeUploadFilesPreservesUnreadablePathReporting(t *testing.T) {
+	t.Parallel()
+
+	missingScanPath := filepath.Join(t.TempDir(), "missing-scan")
+	missingAdditionalPath := filepath.Join(t.TempDir(), "missing-additional")
+	now := time.Now()
+	files, noPermissionPaths, err := ComputeUploadFiles(
+		"unreadable-paths",
+		[]string{missingScanPath},
+		[]string{missingAdditionalPath},
+		nil,
+		true,
+		now.Add(-time.Hour).Unix(),
+		now.Unix(),
+	)
+
+	if err != nil {
+		t.Fatalf("ComputeUploadFiles() error = %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("files = %v, want none", files)
+	}
+	if len(noPermissionPaths) != 2 ||
+		noPermissionPaths[0] != missingScanPath ||
+		noPermissionPaths[1] != missingAdditionalPath {
+		t.Fatalf(
+			"no-permission paths = %v, want [%s %s]",
+			noPermissionPaths,
+			missingScanPath,
+			missingAdditionalPath,
+		)
+	}
+}
+
+func writeUploadTestFile(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	filePath := filepath.Join(dir, name)
+	if err := os.WriteFile(filePath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", filePath, err)
+	}
+	return filePath
+}

--- a/pkg/upload/time_window.go
+++ b/pkg/upload/time_window.go
@@ -29,8 +29,8 @@ const (
 var (
 	// ErrInvalidTimeWindow identifies a permanent request error.
 	ErrInvalidTimeWindow = errors.New("invalid upload time window")
-	// ErrTimeWindowNotReady identifies a retryable request whose start time has
-	// not arrived yet.
+	// ErrTimeWindowNotReady classifies a request whose start time is beyond the
+	// accepted future tolerance. Scan entry points translate it to empty success.
 	ErrTimeWindowNotReady = errors.New("upload time window is not ready")
 )
 
@@ -64,8 +64,8 @@ func (e *TimeWindowError) Unwrap() error {
 	return e.kind
 }
 
-// ValidateTimeWindow rejects permanent invalid ranges and retryable ranges
-// whose start time is still too far in the future. A future end time is valid.
+// ValidateTimeWindow rejects permanently invalid ranges and classifies ranges
+// whose start time is beyond the accepted tolerance. A future end time is valid.
 func ValidateTimeWindow(startTime, endTime int64) error {
 	return validateTimeWindowAt(startTime, endTime, time.Now())
 }

--- a/pkg/upload/time_window.go
+++ b/pkg/upload/time_window.go
@@ -1,0 +1,92 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	// FutureStartTolerance permits ordinary clock skew and short scheduling
+	// jitter without postponing an otherwise runnable scan.
+	FutureStartTolerance = 5 * time.Minute
+)
+
+var (
+	// ErrInvalidTimeWindow identifies a permanent request error.
+	ErrInvalidTimeWindow = errors.New("invalid upload time window")
+	// ErrTimeWindowNotReady identifies a retryable request whose start time has
+	// not arrived yet.
+	ErrTimeWindowNotReady = errors.New("upload time window is not ready")
+)
+
+// TimeWindowError includes the timestamps that caused validation to fail and
+// unwraps to either ErrInvalidTimeWindow or ErrTimeWindowNotReady.
+type TimeWindowError struct {
+	StartTime int64
+	EndTime   int64
+	Now       int64
+	kind      error
+}
+
+func (e *TimeWindowError) Error() string {
+	switch {
+	case errors.Is(e.kind, ErrInvalidTimeWindow):
+		return fmt.Sprintf("%v: start %d is after end %d", e.kind, e.StartTime, e.EndTime)
+	case errors.Is(e.kind, ErrTimeWindowNotReady):
+		return fmt.Sprintf(
+			"%v: start %d is after current time %d plus tolerance %s",
+			e.kind,
+			e.StartTime,
+			e.Now,
+			FutureStartTolerance,
+		)
+	default:
+		return fmt.Sprintf("upload time window validation failed: start=%d end=%d now=%d", e.StartTime, e.EndTime, e.Now)
+	}
+}
+
+func (e *TimeWindowError) Unwrap() error {
+	return e.kind
+}
+
+// ValidateTimeWindow rejects permanent invalid ranges and retryable ranges
+// whose start time is still too far in the future. A future end time is valid.
+func ValidateTimeWindow(startTime, endTime int64) error {
+	return validateTimeWindowAt(startTime, endTime, time.Now())
+}
+
+func validateTimeWindowAt(startTime, endTime int64, now time.Time) error {
+	nowUnix := now.Unix()
+	if startTime > endTime {
+		return &TimeWindowError{
+			StartTime: startTime,
+			EndTime:   endTime,
+			Now:       nowUnix,
+			kind:      ErrInvalidTimeWindow,
+		}
+	}
+	if startTime > now.Add(FutureStartTolerance).Unix() {
+		return &TimeWindowError{
+			StartTime: startTime,
+			EndTime:   endTime,
+			Now:       nowUnix,
+			kind:      ErrTimeWindowNotReady,
+		}
+	}
+	return nil
+}

--- a/pkg/upload/time_window_test.go
+++ b/pkg/upload/time_window_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestValidateTimeWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_000_000, 0)
+	tests := []struct {
+		name      string
+		startTime int64
+		endTime   int64
+		wantErr   error
+	}{
+		{
+			name:      "invalid order is permanent",
+			startTime: now.Unix() + 1,
+			endTime:   now.Unix(),
+			wantErr:   ErrInvalidTimeWindow,
+		},
+		{
+			name:      "start at tolerance boundary is runnable",
+			startTime: now.Add(FutureStartTolerance).Unix(),
+			endTime:   now.Add(FutureStartTolerance + time.Minute).Unix(),
+		},
+		{
+			name:      "start beyond tolerance is retryable",
+			startTime: now.Add(FutureStartTolerance + time.Second).Unix(),
+			endTime:   now.Add(FutureStartTolerance + time.Minute).Unix(),
+			wantErr:   ErrTimeWindowNotReady,
+		},
+		{
+			name:      "future end is runnable",
+			startTime: now.Add(-time.Minute).Unix(),
+			endTime:   now.Add(24 * time.Hour).Unix(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateTimeWindowAt(tc.startTime, tc.endTime, now)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/upload/time_window_test.go
+++ b/pkg/upload/time_window_test.go
@@ -42,7 +42,7 @@ func TestValidateTimeWindow(t *testing.T) {
 			endTime:   now.Add(FutureStartTolerance + time.Minute).Unix(),
 		},
 		{
-			name:      "start beyond tolerance is retryable",
+			name:      "start beyond tolerance is classified for empty success",
 			startTime: now.Add(FutureStartTolerance + time.Second).Unix(),
 			endTime:   now.Add(FutureStartTolerance + time.Minute).Unix(),
 			wantErr:   ErrTimeWindowNotReady,

--- a/pkg/utils/symwalk.go
+++ b/pkg/utils/symwalk.go
@@ -34,7 +34,8 @@ type SymWalkOptions struct {
 	// instead of returning an error.
 	SkipPermissionErrors bool
 
-	// MaxFiles limits the maximum number of files to collect in GetAllFilePaths.
+	// MaxFiles limits the maximum number of files processed by WalkFilePaths
+	// or collected by GetAllFilePaths.
 	// When set to 0, no limit is applied. Default is 10000.
 	// This helps prevent memory issues when traversing large directory structures
 	// or when symbolic links point to root directories.
@@ -305,6 +306,37 @@ func IsSymlink(fi os.FileInfo) bool {
 	return fi.Mode()&os.ModeSymlink != 0
 }
 
+// WalkFilePaths walks the file tree rooted at root and invokes walkFn
+// immediately for every file found. It uses the same symbolic link handling,
+// permission handling, empty-file filtering, and file limit as
+// GetAllFilePaths.
+func WalkFilePaths(root string, options *SymWalkOptions, walkFn func(string) error) error {
+	if options == nil {
+		options = DefaultSymWalkOptions()
+	}
+
+	fileCount := 0
+	return SymWalk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if options.MaxFiles > 0 && fileCount >= options.MaxFiles {
+			log.Warnf("WalkFilePaths: reached maximum file limit (%d), stopping traversal at path: %s", options.MaxFiles, path)
+			return filepath.SkipDir
+		}
+
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		fileCount++
+		return walkFn(absPath)
+	}, options)
+}
+
 // GetAllFilePaths walks the file tree rooted at root and returns a slice of absolute paths
 // for all files (not directories) found. It uses the same symbolic link handling and
 // permission error handling as SymWalk. By default, empty files (size 0) are skipped
@@ -319,34 +351,10 @@ func GetAllFilePaths(root string, options *SymWalkOptions) ([]string, error) {
 	}
 
 	var filePaths []string
-
-	// Define the walk function that collects file paths
-	walkFn := func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		// Only collect regular files, not directories
-		if !info.IsDir() {
-			// Check if we've reached the maximum number of files
-			if options.MaxFiles > 0 && len(filePaths) >= options.MaxFiles {
-				log.Warnf("GetAllFilePaths: reached maximum file limit (%d), stopping collection at path: %s", options.MaxFiles, path)
-				return filepath.SkipDir // Stop traversal
-			}
-
-			// Convert to absolute path
-			absPath, err := filepath.Abs(path)
-			if err != nil {
-				return err
-			}
-			filePaths = append(filePaths, absPath)
-		}
-
+	err := WalkFilePaths(root, options, func(path string) error {
+		filePaths = append(filePaths, path)
 		return nil
-	}
-
-	// Walk the directory tree
-	err := SymWalk(root, walkFn, options)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/symwalk_test.go
+++ b/pkg/utils/symwalk_test.go
@@ -19,12 +19,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
 )
 
-var errOther = errors.New("other error")
+var (
+	errOther         = errors.New("other error")
+	errWalkFilePaths = errors.New("callback failed")
+)
 
 // Example: custom configuration.
 func ExampleSymWalk_custom() {
@@ -806,6 +811,465 @@ func TestGetAllFilePaths_MaxFilesLimit(t *testing.T) {
 	if len(paths) != maxFiles {
 		t.Errorf("Expected exactly %d files, got %d", maxFiles, len(paths))
 	}
+}
+
+func TestWalkFilePathsProcessesFilesBeforeLaterTraversalError(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	firstPath := filepath.Join(root, "a-file.txt")
+	if err := os.WriteFile(firstPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write first file: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(root, "missing-target"), filepath.Join(root, "z-broken-link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	var visited []string
+	err := WalkFilePaths(root, &SymWalkOptions{
+		FollowSymlinks:       true,
+		SkipPermissionErrors: false,
+		SkipEmptyFiles:       true,
+		MaxFiles:             99999,
+	}, func(filePath string) error {
+		visited = append(visited, filePath)
+		return nil
+	})
+
+	if err == nil {
+		t.Fatal("WalkFilePaths() error = nil, want broken symlink traversal error")
+	}
+	if len(visited) != 1 || visited[0] != firstPath {
+		t.Fatalf("visited = %v, want first file processed before later traversal error", visited)
+	}
+}
+
+func TestWalkFilePathsMatchesLegacyCollector(t *testing.T) {
+	t.Parallel()
+
+	t.Run("directory order, absolute paths, empty files, and limits", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		nested := filepath.Join(root, "b-dir")
+		if err := os.Mkdir(nested, 0o755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+		for path, content := range map[string]string{
+			filepath.Join(root, "a.txt"):          "a",
+			filepath.Join(root, "c-empty.txt"):    "",
+			filepath.Join(nested, "a-empty.txt"):  "",
+			filepath.Join(nested, "b-nested.txt"): "nested",
+		} {
+			if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+				t.Fatalf("write %s: %v", path, err)
+			}
+		}
+
+		cases := []struct {
+			name    string
+			options *SymWalkOptions
+		}{
+			{name: "nil defaults", options: nil},
+			{
+				name: "include empty and unlimited",
+				options: &SymWalkOptions{
+					FollowSymlinks:       true,
+					SkipPermissionErrors: true,
+					SkipEmptyFiles:       false,
+					MaxFiles:             0,
+				},
+			},
+			{
+				name: "limit one",
+				options: &SymWalkOptions{
+					FollowSymlinks:       true,
+					SkipPermissionErrors: true,
+					SkipEmptyFiles:       false,
+					MaxFiles:             1,
+				},
+			},
+			{
+				name: "limit at exact file count",
+				options: &SymWalkOptions{
+					FollowSymlinks:       true,
+					SkipPermissionErrors: true,
+					SkipEmptyFiles:       false,
+					MaxFiles:             4,
+				},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				assertWalkFilePathsMatchesLegacy(t, root, tc.options)
+			})
+		}
+	})
+
+	t.Run("file roots", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		nonEmpty := filepath.Join(root, "non-empty.txt")
+		empty := filepath.Join(root, "empty.txt")
+		if err := os.WriteFile(nonEmpty, []byte("data"), 0o600); err != nil {
+			t.Fatalf("write non-empty root: %v", err)
+		}
+		if err := os.WriteFile(empty, nil, 0o600); err != nil {
+			t.Fatalf("write empty root: %v", err)
+		}
+
+		assertWalkFilePathsMatchesLegacy(t, nonEmpty, nil)
+		assertWalkFilePathsMatchesLegacy(t, empty, nil)
+		assertWalkFilePathsMatchesLegacy(t, empty, &SymWalkOptions{
+			FollowSymlinks:       true,
+			SkipPermissionErrors: true,
+			SkipEmptyFiles:       false,
+			MaxFiles:             0,
+		})
+	})
+
+	t.Run("relative root becomes absolute", func(t *testing.T) {
+		t.Parallel()
+
+		filePath := filepath.Join(t.TempDir(), "relative.txt")
+		if err := os.WriteFile(filePath, []byte("data"), 0o600); err != nil {
+			t.Fatalf("write relative-root file: %v", err)
+		}
+		workingDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("get working directory: %v", err)
+		}
+		relativePath, err := filepath.Rel(workingDir, filePath)
+		if err != nil {
+			t.Fatalf("make relative path: %v", err)
+		}
+		assertWalkFilePathsMatchesLegacy(t, relativePath, nil)
+	})
+}
+
+func TestWalkFilePathsMatchesLegacySymlinkVisitedBehavior(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	targetFile := filepath.Join(root, "z-target.txt")
+	if err := os.WriteFile(targetFile, []byte("target"), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	targetDir := filepath.Join(root, "z-target-dir")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	targetDirFile := filepath.Join(targetDir, "file.txt")
+	if err := os.WriteFile(targetDirFile, []byte("nested"), 0o600); err != nil {
+		t.Fatalf("write target dir file: %v", err)
+	}
+
+	for link, target := range map[string]string{
+		filepath.Join(root, "a-file-link"): targetFile,
+		filepath.Join(root, "b-file-link"): targetFile,
+		filepath.Join(root, "c-dir-link"):  targetDir,
+		filepath.Join(root, "d-dir-link"):  targetDir,
+	} {
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+	}
+
+	followOptions := &SymWalkOptions{
+		FollowSymlinks:       true,
+		SkipPermissionErrors: false,
+		SkipEmptyFiles:       false,
+		MaxFiles:             0,
+	}
+	assertWalkFilePathsMatchesLegacy(t, root, followOptions)
+	followedPaths, err := legacyGetAllFilePathsForTest(root, followOptions)
+	if err != nil {
+		t.Fatalf("legacy followed collector error = %v", err)
+	}
+	wantFollowed := []string{
+		filepath.Join(root, "a-file-link"),
+		filepath.Join(root, "c-dir-link", "file.txt"),
+		targetDirFile,
+		targetFile,
+	}
+	if !reflect.DeepEqual(followedPaths, wantFollowed) {
+		t.Fatalf("followed paths = %v, want visited-target order %v", followedPaths, wantFollowed)
+	}
+
+	noFollowOptions := &SymWalkOptions{
+		FollowSymlinks:       false,
+		SkipPermissionErrors: false,
+		SkipEmptyFiles:       false,
+		MaxFiles:             0,
+	}
+	assertWalkFilePathsMatchesLegacy(t, root, noFollowOptions)
+	notFollowedPaths, err := legacyGetAllFilePathsForTest(root, noFollowOptions)
+	if err != nil {
+		t.Fatalf("legacy non-followed collector error = %v", err)
+	}
+	wantNotFollowed := []string{
+		filepath.Join(root, "a-file-link"),
+		filepath.Join(root, "b-file-link"),
+		filepath.Join(root, "c-dir-link"),
+		filepath.Join(root, "d-dir-link"),
+		targetDirFile,
+		targetFile,
+	}
+	if !reflect.DeepEqual(notFollowedPaths, wantNotFollowed) {
+		t.Fatalf("non-followed paths = %v, want %v", notFollowedPaths, wantNotFollowed)
+	}
+}
+
+func TestWalkFilePathsMatchesLegacyBrokenAndCyclicSymlinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("broken symlink", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		broken := filepath.Join(root, "broken")
+		if err := os.Symlink(filepath.Join(root, "missing"), broken); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+
+		assertWalkFilePathsMatchesLegacy(t, root, &SymWalkOptions{
+			FollowSymlinks:       false,
+			SkipPermissionErrors: false,
+			SkipEmptyFiles:       false,
+			MaxFiles:             0,
+		})
+
+		legacyPaths, legacyErr := legacyGetAllFilePathsForTest(root, &SymWalkOptions{
+			FollowSymlinks:       true,
+			SkipPermissionErrors: false,
+			SkipEmptyFiles:       false,
+			MaxFiles:             0,
+		})
+		currentPaths, currentErr := GetAllFilePaths(root, &SymWalkOptions{
+			FollowSymlinks:       true,
+			SkipPermissionErrors: false,
+			SkipEmptyFiles:       false,
+			MaxFiles:             0,
+		})
+		if legacyErr == nil || currentErr == nil {
+			t.Fatalf("legacy error = %v, current error = %v; both must reject a followed broken link", legacyErr, currentErr)
+		}
+		if legacyPaths != nil || currentPaths != nil {
+			t.Fatalf("legacy paths = %v, current paths = %v; both must be atomic on error", legacyPaths, currentPaths)
+		}
+	})
+
+	t.Run("directory cycle", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		dir := filepath.Join(root, "dir")
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatalf("mkdir cycle dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0o600); err != nil {
+			t.Fatalf("write cycle file: %v", err)
+		}
+		if err := os.Symlink(root, filepath.Join(dir, "back-to-root")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+
+		assertWalkFilePathsMatchesLegacy(t, root, &SymWalkOptions{
+			FollowSymlinks:       true,
+			SkipPermissionErrors: false,
+			SkipEmptyFiles:       false,
+			MaxFiles:             0,
+		})
+	})
+}
+
+func TestWalkFilePathsPermissionErrorCompatibility(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission test")
+	}
+
+	root := t.TempDir()
+	firstPath := filepath.Join(root, "a-file.txt")
+	if err := os.WriteFile(firstPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write first file: %v", err)
+	}
+	deniedDir := filepath.Join(root, "z-denied")
+	if err := os.Mkdir(deniedDir, 0o700); err != nil {
+		t.Fatalf("mkdir denied dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(deniedDir, "hidden.txt"), []byte("hidden"), 0o600); err != nil {
+		t.Fatalf("write hidden file: %v", err)
+	}
+	if err := os.Chmod(deniedDir, 0); err != nil {
+		t.Fatalf("chmod denied dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(deniedDir, 0o700)
+	})
+	if _, err := os.ReadDir(deniedDir); err == nil {
+		t.Skip("test process can read mode-000 directories")
+	}
+
+	assertWalkFilePathsMatchesLegacy(t, root, &SymWalkOptions{
+		FollowSymlinks:       true,
+		SkipPermissionErrors: true,
+		SkipEmptyFiles:       false,
+		MaxFiles:             0,
+	})
+
+	strictOptions := &SymWalkOptions{
+		FollowSymlinks:       true,
+		SkipPermissionErrors: false,
+		SkipEmptyFiles:       false,
+		MaxFiles:             0,
+	}
+	legacyPaths, legacyErr := legacyGetAllFilePathsForTest(root, strictOptions)
+	currentPaths, currentErr := GetAllFilePaths(root, strictOptions)
+	if !errors.Is(legacyErr, os.ErrPermission) || !errors.Is(currentErr, os.ErrPermission) {
+		t.Fatalf("legacy error = %v, current error = %v; both must propagate permission failure", legacyErr, currentErr)
+	}
+	if legacyPaths != nil || currentPaths != nil {
+		t.Fatalf("legacy paths = %v, current paths = %v; collectors must be atomic on permission failure", legacyPaths, currentPaths)
+	}
+
+	var streamed []string
+	streamErr := WalkFilePaths(root, strictOptions, func(filePath string) error {
+		streamed = append(streamed, filePath)
+		return nil
+	})
+	if !errors.Is(streamErr, os.ErrPermission) {
+		t.Fatalf("WalkFilePaths() error = %v, want permission failure", streamErr)
+	}
+	if !reflect.DeepEqual(streamed, []string{firstPath}) {
+		t.Fatalf("streamed = %v, want callback before later permission failure", streamed)
+	}
+}
+
+func TestWalkFilePathsCallbackControlErrors(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	for _, name := range []string{"a.txt", "b.txt"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("data"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	options := &SymWalkOptions{
+		FollowSymlinks:       true,
+		SkipPermissionErrors: false,
+		SkipEmptyFiles:       false,
+		MaxFiles:             0,
+	}
+
+	t.Run("ordinary error propagates", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := WalkFilePaths(root, options, func(string) error {
+			calls++
+			return errWalkFilePaths
+		})
+		if !errors.Is(err, errWalkFilePaths) {
+			t.Fatalf("WalkFilePaths() error = %v, want %v", err, errWalkFilePaths)
+		}
+		if calls != 1 {
+			t.Fatalf("callback calls = %d, want 1", calls)
+		}
+	})
+
+	t.Run("SkipDir stops successfully", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := WalkFilePaths(root, options, func(string) error {
+			calls++
+			return filepath.SkipDir
+		})
+		if err != nil {
+			t.Fatalf("WalkFilePaths() error = %v, want nil", err)
+		}
+		if calls != 1 {
+			t.Fatalf("callback calls = %d, want 1", calls)
+		}
+	})
+
+	t.Run("SkipAll propagates for caller classification", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := WalkFilePaths(root, options, func(string) error {
+			calls++
+			return filepath.SkipAll
+		})
+		if !errors.Is(err, filepath.SkipAll) {
+			t.Fatalf("WalkFilePaths() error = %v, want filepath.SkipAll", err)
+		}
+		if calls != 1 {
+			t.Fatalf("callback calls = %d, want 1", calls)
+		}
+	})
+}
+
+func assertWalkFilePathsMatchesLegacy(t *testing.T, root string, options *SymWalkOptions) {
+	t.Helper()
+
+	legacyPaths, legacyErr := legacyGetAllFilePathsForTest(root, options)
+	if legacyErr != nil {
+		t.Fatalf("legacy collector error = %v", legacyErr)
+	}
+
+	var streamedPaths []string
+	streamErr := WalkFilePaths(root, options, func(filePath string) error {
+		streamedPaths = append(streamedPaths, filePath)
+		return nil
+	})
+	if streamErr != nil {
+		t.Fatalf("WalkFilePaths() error = %v", streamErr)
+	}
+	if !reflect.DeepEqual(streamedPaths, legacyPaths) {
+		t.Fatalf("WalkFilePaths() = %v, legacy collector = %v", streamedPaths, legacyPaths)
+	}
+
+	currentPaths, currentErr := GetAllFilePaths(root, options)
+	if currentErr != nil {
+		t.Fatalf("GetAllFilePaths() error = %v", currentErr)
+	}
+	if !reflect.DeepEqual(currentPaths, legacyPaths) {
+		t.Fatalf("GetAllFilePaths() = %v, legacy collector = %v", currentPaths, legacyPaths)
+	}
+}
+
+// legacyGetAllFilePathsForTest independently reconstructs the implementation
+// from main before GetAllFilePaths delegated to WalkFilePaths.
+func legacyGetAllFilePathsForTest(root string, options *SymWalkOptions) ([]string, error) {
+	if options == nil {
+		options = DefaultSymWalkOptions()
+	}
+
+	var filePaths []string
+	err := SymWalk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if options.MaxFiles > 0 && len(filePaths) >= options.MaxFiles {
+			return filepath.SkipDir
+		}
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		filePaths = append(filePaths, absPath)
+		return nil
+	}, options)
+	if err != nil {
+		return nil, err
+	}
+	return filePaths, nil
 }
 
 // Test GetAllFilePaths with MaxFiles set to 0 (no limit).


### PR DESCRIPTION
## Summary

File scans now preserve legacy traversal semantics while avoiding an all-paths allocation, and time-window outcomes are resolved before scan filesystem access. `start > end` is a permanent invalid result; `start > now + 5m` completes immediately as a successful empty scan; and a future `end` never delays collection.

The empty-success outcome is propagated through the full device workflow: new slaves return `Success=true` with no files, upload tasks transition through `PROCESSING` to `SUCCEEDED` without scanning or contacting slaves, and rule `CollectInfo` is consumed without inspecting scan roots. For mixed deployments, the master still recognizes an older slave's `TIME_WINDOW_NOT_READY` response but treats that response as empty, preserving local files and successful responses from other slaves; permanent invalidity still takes precedence.

Recursive scans now consume paths as they are discovered instead of first retaining every candidate path. An independent reconstruction of the previous `GetAllFilePaths` implementation constrains lexical order, absolute paths, empty files, limits, permission behavior, whitelist filtering, symlinks, cycles, callback errors, and late traversal failures. Callers that historically committed results only after a successful directory walk retain that atomicity through per-directory buffering or file-state rollback.

The five-minute future-start tolerance absorbs ordinary device clock skew and short scheduling jitter. Starts within that tolerance remain runnable; starts beyond it are considered stale/mistimed work and are abandoned as empty success without sleeping, retrying, or keeping master work pending.

## Validation

- Focused time-window and propagation tests:
  `go test ./pkg/upload ./internal/master ./internal/slave ./internal/mod/task ./internal/mod/rule -count=1`
- Race:
  `go test -race ./pkg/utils ./pkg/upload ./internal/master ./internal/mod/task ./internal/mod/rule ./internal/mod/rule/file_state_handler ./internal/slave -count=1`
- Full repository:
  `go test ./... -count=1`
- `go vet ./...`
- `GOTOOLCHAIN=go1.26.2 make lint`
- `git diff --check`

## Residual risks

- `ComputeUploadFiles` now returns an error as a third result; all repository callers are migrated, but external Go callers need a source update.
- The five-minute tolerance is intentionally fixed rather than configurable.
- Permission-denied coverage conditionally skips on privileged runners that can read mode-`000` directories.
- Mixed-version compatibility is intentionally one-way at the status boundary: new slaves emit standard empty success, while the current master also consumes the legacy `TIME_WINDOW_NOT_READY` code as empty.

Queued-byte budgets, window-span limits, log sampling, and file-size semantics remain intentionally out of scope.

## Post-Deploy Monitoring & Validation

- For the first 24 hours, the device/edge service owner should watch upload-task pending age and failure counts plus rule collect-info backlog.
- Healthy behavior: future-start tasks move directly through `PROCESSING`/`SUCCEEDED`, rule collect info is consumed, and logs contain the empty-success or legacy-not-ready compatibility messages without scan-path permission errors.
- Investigate or roll back if future-start work remains pending, invalid `start > end` windows are marked successful, or future-start requests produce filesystem scan activity.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coScout/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787845325&installation_model_id=425002&pr_number=227&repository=coscene-io%2FcoScout&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoScout%2Fpull%2F227&signature=24bfc9cc7a413d6d751057675cb4c2818fab67dfd5dc6e5eeaac5f7d62a8eceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
