### PR TITLE
fix: harden runtime cancellation, reloads, and decoding

### DIFF
--- a/cmd/coscout/commands/daemon.go
+++ b/cmd/coscout/commands/daemon.go
@@ -31,7 +31,25 @@ import (
 )
 
 type authState struct {
-	isAuthed atomic.Bool
+	lifecycle atomic.Int32
+}
+
+const (
+	daemonIdle int32 = iota
+	daemonRunning
+	daemonStopping
+)
+
+func (s *authState) tryStart() bool {
+	return s.lifecycle.CompareAndSwap(daemonIdle, daemonRunning)
+}
+
+func (s *authState) requestStop() bool {
+	return s.lifecycle.CompareAndSwap(daemonRunning, daemonStopping)
+}
+
+func (s *authState) daemonStopped() {
+	s.lifecycle.Store(daemonIdle)
 }
 
 func NewDaemonCommand(cfgPath *string) *cobra.Command {
@@ -74,23 +92,25 @@ func run(confManager *config.ConfManager, reqClient *api.RequestClient, register
 	errorChan := make(chan error, 100)
 
 	state := &authState{}
-	state.isAuthed.Store(false)
 	for deviceStatus := range registerChan {
 		if deviceStatus.Authorized {
 			log.Info("Device is authorized. Performing actions...")
 
-			if !state.isAuthed.Load() {
-				go daemon.Run(confManager, reqClient, startChan, exitChan, errorChan)
+			if state.tryStart() {
 				startChan <- true
+				go func() {
+					defer state.daemonStopped()
+					if err := daemon.Run(confManager, reqClient, startChan, exitChan, errorChan); err != nil {
+						log.Errorf("Daemon stopped: %v", err)
+					}
+				}()
 			}
-			state.isAuthed.Store(true)
 		} else {
 			log.Warn("Device is not authorized, waiting...")
 
-			if state.isAuthed.Load() {
+			if state.requestStop() {
 				exitChan <- true
 			}
-			state.isAuthed.Store(false)
 		}
 	}
 }

--- a/cmd/coscout/commands/daemon.go
+++ b/cmd/coscout/commands/daemon.go
@@ -15,8 +15,10 @@
 package commands
 
 import (
+	"context"
 	"os"
 	"os/signal"
+	"sync"
 	"sync/atomic"
 	"syscall"
 
@@ -32,6 +34,8 @@ import (
 
 type authState struct {
 	lifecycle atomic.Int32
+	cancelMu  sync.Mutex
+	cancel    context.CancelFunc
 }
 
 const (
@@ -40,16 +44,45 @@ const (
 	daemonStopping
 )
 
-func (s *authState) tryStart() bool {
-	return s.lifecycle.CompareAndSwap(daemonIdle, daemonRunning)
+func (s *authState) tryStart() (context.Context, bool) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s.cancelMu.Lock()
+	defer s.cancelMu.Unlock()
+	if !s.lifecycle.CompareAndSwap(daemonIdle, daemonRunning) {
+		cancel()
+		return nil, false
+	}
+	s.cancel = cancel
+	return ctx, true
 }
 
 func (s *authState) requestStop() bool {
-	return s.lifecycle.CompareAndSwap(daemonRunning, daemonStopping)
+	if !s.lifecycle.CompareAndSwap(daemonRunning, daemonStopping) {
+		return false
+	}
+
+	s.cancelMu.Lock()
+	cancel := s.cancel
+	s.cancelMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	return true
 }
 
 func (s *authState) daemonStopped() {
-	s.lifecycle.Store(daemonIdle)
+	s.cancelMu.Lock()
+	cancelRunAndMarkIdle(s.cancel, &s.lifecycle)
+	s.cancel = nil
+	s.cancelMu.Unlock()
+}
+
+func cancelRunAndMarkIdle(cancel context.CancelFunc, lifecycle *atomic.Int32) {
+	if cancel != nil {
+		cancel()
+	}
+	lifecycle.Store(daemonIdle)
 }
 
 func NewDaemonCommand(cfgPath *string) *cobra.Command {
@@ -87,18 +120,16 @@ func NewDaemonCommand(cfgPath *string) *cobra.Command {
 }
 
 func run(confManager *config.ConfManager, reqClient *api.RequestClient, registerChan chan model.DeviceStatusResponse) {
-	startChan := make(chan bool, 1)
-	exitChan := make(chan bool, 1)
 	errorChan := make(chan error, 100)
 
 	state := &authState{}
 	for deviceStatus := range registerChan {
 		if deviceStatus.Authorized {
-			startDaemon(state, confManager, reqClient, startChan, exitChan, errorChan)
+			startDaemon(state, confManager, reqClient, errorChan)
 			continue
 		}
 
-		stopDaemon(state, exitChan)
+		stopDaemon(state)
 	}
 }
 
@@ -106,26 +137,23 @@ func startDaemon(
 	state *authState,
 	confManager *config.ConfManager,
 	reqClient *api.RequestClient,
-	startChan, exitChan chan bool,
 	errorChan chan error,
 ) {
 	log.Info("Device is authorized. Performing actions...")
-	if !state.tryStart() {
+	ctx, started := state.tryStart()
+	if !started {
 		return
 	}
 
-	startChan <- true
 	go func() {
 		defer state.daemonStopped()
-		if err := daemon.Run(confManager, reqClient, startChan, exitChan, errorChan); err != nil {
+		if err := daemon.Run(ctx, confManager, reqClient, errorChan); err != nil {
 			log.Errorf("Daemon stopped: %v", err)
 		}
 	}()
 }
 
-func stopDaemon(state *authState, exitChan chan bool) {
+func stopDaemon(state *authState) {
 	log.Warn("Device is not authorized, waiting...")
-	if state.requestStop() {
-		exitChan <- true
-	}
+	state.requestStop()
 }

--- a/cmd/coscout/commands/daemon.go
+++ b/cmd/coscout/commands/daemon.go
@@ -94,23 +94,38 @@ func run(confManager *config.ConfManager, reqClient *api.RequestClient, register
 	state := &authState{}
 	for deviceStatus := range registerChan {
 		if deviceStatus.Authorized {
-			log.Info("Device is authorized. Performing actions...")
-
-			if state.tryStart() {
-				startChan <- true
-				go func() {
-					defer state.daemonStopped()
-					if err := daemon.Run(confManager, reqClient, startChan, exitChan, errorChan); err != nil {
-						log.Errorf("Daemon stopped: %v", err)
-					}
-				}()
-			}
-		} else {
-			log.Warn("Device is not authorized, waiting...")
-
-			if state.requestStop() {
-				exitChan <- true
-			}
+			startDaemon(state, confManager, reqClient, startChan, exitChan, errorChan)
+			continue
 		}
+
+		stopDaemon(state, exitChan)
+	}
+}
+
+func startDaemon(
+	state *authState,
+	confManager *config.ConfManager,
+	reqClient *api.RequestClient,
+	startChan, exitChan chan bool,
+	errorChan chan error,
+) {
+	log.Info("Device is authorized. Performing actions...")
+	if !state.tryStart() {
+		return
+	}
+
+	startChan <- true
+	go func() {
+		defer state.daemonStopped()
+		if err := daemon.Run(confManager, reqClient, startChan, exitChan, errorChan); err != nil {
+			log.Errorf("Daemon stopped: %v", err)
+		}
+	}()
+}
+
+func stopDaemon(state *authState, exitChan chan bool) {
+	log.Warn("Device is not authorized, waiting...")
+	if state.requestStop() {
+		exitChan <- true
 	}
 }

--- a/cmd/coscout/commands/daemon.go
+++ b/cmd/coscout/commands/daemon.go
@@ -42,7 +42,7 @@ func NewDaemonCommand(cfgPath *string) *cobra.Command {
 			storageDB := storage.NewBoltDB(config.GetDBPath())
 			confManager := config.InitConfManager(*cfgPath, &storageDB)
 
-			appConf, err := confManager.LoadOnce()
+			appConf, err := confManager.LoadStartup()
 			if err != nil {
 				log.Fatalf("Unable to load config file from %s: %v", *cfgPath, err)
 			}

--- a/cmd/coscout/commands/daemon.go
+++ b/cmd/coscout/commands/daemon.go
@@ -42,7 +42,10 @@ func NewDaemonCommand(cfgPath *string) *cobra.Command {
 			storageDB := storage.NewBoltDB(config.GetDBPath())
 			confManager := config.InitConfManager(*cfgPath, &storageDB)
 
-			appConf := confManager.LoadOnce()
+			appConf, err := confManager.LoadOnce()
+			if err != nil {
+				log.Fatalf("Unable to load config file from %s: %v", *cfgPath, err)
+			}
 			log.Infof("Load config file from %s", *cfgPath)
 
 			registerChan := make(chan model.DeviceStatusResponse, 10)

--- a/cmd/coscout/commands/daemon_test.go
+++ b/cmd/coscout/commands/daemon_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestAuthStateCanRetryAfterDaemonStops(t *testing.T) {
+	t.Parallel()
+
 	state := &authState{}
 
 	require.True(t, state.tryStart())

--- a/cmd/coscout/commands/daemon_test.go
+++ b/cmd/coscout/commands/daemon_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthStateCanRetryAfterDaemonStops(t *testing.T) {
+	state := &authState{}
+
+	require.True(t, state.tryStart())
+	require.False(t, state.tryStart())
+	require.True(t, state.requestStop())
+	require.False(t, state.requestStop())
+	require.False(t, state.tryStart())
+
+	state.daemonStopped()
+	require.True(t, state.tryStart())
+}

--- a/cmd/coscout/commands/daemon_test.go
+++ b/cmd/coscout/commands/daemon_test.go
@@ -15,22 +15,79 @@
 package commands
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestAuthStateCanRetryAfterDaemonStops(t *testing.T) {
+func TestAuthStateStopFromFailedRunDoesNotCancelRestart(t *testing.T) {
 	t.Parallel()
 
 	state := &authState{}
 
-	require.True(t, state.tryStart())
-	require.False(t, state.tryStart())
+	firstCtx, started := state.tryStart()
+	require.True(t, started)
+	_, started = state.tryStart()
+	require.False(t, started)
 	require.True(t, state.requestStop())
 	require.False(t, state.requestStop())
-	require.False(t, state.tryStart())
+	require.ErrorIs(t, firstCtx.Err(), context.Canceled)
+	_, started = state.tryStart()
+	require.False(t, started)
 
 	state.daemonStopped()
-	require.True(t, state.tryStart())
+	secondCtx, started := state.tryStart()
+	require.True(t, started)
+	require.NoError(t, secondCtx.Err(), "a previous stop must not cancel a restarted daemon")
+}
+
+func TestAuthStateRepeatedAuthorizationTransitionsAreIdempotent(t *testing.T) {
+	t.Parallel()
+
+	state := &authState{}
+	for range 10 {
+		runCtx, started := state.tryStart()
+		require.True(t, started)
+
+		_, started = state.tryStart()
+		require.False(t, started, "duplicate authorization must not start another daemon")
+		require.True(t, state.requestStop())
+		require.False(t, state.requestStop(), "duplicate unauthorization must not request another stop")
+		require.ErrorIs(t, runCtx.Err(), context.Canceled)
+
+		state.daemonStopped()
+	}
+}
+
+func TestDaemonStoppedCancelsOldRunBeforeRestart(t *testing.T) {
+	t.Parallel()
+
+	state := &authState{}
+	firstCtx, started := state.tryStart()
+	require.True(t, started)
+
+	state.daemonStopped()
+
+	secondCtx, started := state.tryStart()
+	require.True(t, started)
+	require.ErrorIs(t, firstCtx.Err(), context.Canceled)
+	require.NoError(t, secondCtx.Err())
+}
+
+func TestCancelRunAndMarkIdleOrdersCancellationFirst(t *testing.T) {
+	t.Parallel()
+
+	var lifecycle atomic.Int32
+	lifecycle.Store(daemonRunning)
+	runCtx, cancel := context.WithCancel(t.Context())
+
+	cancelRunAndMarkIdle(func() {
+		require.Equal(t, daemonRunning, lifecycle.Load(), "idle became visible before the old run was canceled")
+		cancel()
+	}, &lifecycle)
+
+	require.ErrorIs(t, runCtx.Err(), context.Canceled)
+	require.Equal(t, daemonIdle, lifecycle.Load())
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -117,7 +117,14 @@ func Collect(ctx context.Context, reqClient *api.RequestClient, confManager *con
 						}
 					}()
 
-					appConfig := confManager.LoadWithRemote()
+					appConfig, configErr := confManager.LoadWithRemote()
+					if configErr != nil {
+						if appConfig == nil {
+							log.Errorf("Unable to load collector config: %v", configErr)
+							return
+						}
+						log.Warnf("Unable to reload collector config, using last-known-good config: %v", configErr)
+					}
 					getStorage := confManager.GetStorage()
 
 					err := handleRecordCaches(uploadChan, reqClient, appConfig, getStorage, recordSet)

--- a/internal/collector/upload.go
+++ b/internal/collector/upload.go
@@ -142,7 +142,14 @@ func Upload(ctx context.Context, reqClient *api.RequestClient, confManager *conf
 						return
 					}
 
-					appConfig := confManager.LoadWithRemote()
+					appConfig, configErr := confManager.LoadWithRemote()
+					if configErr != nil {
+						if appConfig == nil {
+							log.Errorf("Unable to load upload config: %v", configErr)
+							return
+						}
+						log.Warnf("Unable to reload upload config, using last-known-good config: %v", configErr)
+					}
 					if appConfig != nil {
 						enabled := appConfig.Upload.NetworkRule.Enabled
 						blackInterfaces := appConfig.Upload.NetworkRule.BlackInterfaces
@@ -219,7 +226,13 @@ func uploadFiles(ctx context.Context, reqClient *api.RequestClient, confManager 
 	}
 
 	allCompleted := true
-	appConfig := confManager.LoadWithRemote()
+	appConfig, configErr := confManager.LoadWithRemote()
+	if configErr != nil {
+		if appConfig == nil {
+			return errors.Wrap(configErr, "load upload config")
+		}
+		log.Warnf("Unable to reload upload config, using last-known-good config: %v", configErr)
+	}
 	getStorage := confManager.GetStorage()
 
 	recordCache, err := recordCache.Reload()

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/coscene-io/coscout/internal/storage"
 	"github.com/coscene-io/coscout/pkg/constant"
@@ -25,6 +26,7 @@ import (
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/rawbytes"
 	"github.com/knadh/koanf/v2"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -36,12 +38,19 @@ const (
 type ConfManager struct {
 	cfg     string
 	storage *storage.Storage
+	cache   *configCache
+}
+
+type configCache struct {
+	mu       sync.RWMutex
+	lastGood *AppConfig
 }
 
 func InitConfManager(cfg string, s *storage.Storage) *ConfManager {
 	return &ConfManager{
 		cfg:     cfg,
 		storage: s,
+		cache:   &configCache{},
 	}
 }
 
@@ -83,11 +92,11 @@ func (c ConfManager) getDefaultConfig() AppConfig {
 	}
 }
 
-func (c ConfManager) LoadOnce() AppConfig {
+func (c ConfManager) LoadOnce() (AppConfig, error) {
 	appConf := c.getDefaultConfig()
 
 	if err := utils.ParseYAML(c.cfg, &appConf); err != nil {
-		log.Fatalf("unable to load cos config: %v", err)
+		return AppConfig{}, errors.Wrap(err, "unable to load cos config")
 	}
 	for _, f := range appConf.Import {
 		if strings.HasPrefix(f, RemoteFilePrefix) {
@@ -101,20 +110,26 @@ func (c ConfManager) LoadOnce() AppConfig {
 		}
 
 		if err := utils.ParseYAML(localPath, &appConf); err != nil {
-			log.Fatalf("unable to load cos config: %v", err)
+			return AppConfig{}, errors.Wrapf(err, "unable to load local config %s", localPath)
 		}
 	}
-	return appConf
+	return appConf, nil
 }
 
-func (c ConfManager) LoadWithRemote() *AppConfig {
-	appConf := c.LoadOnce()
+func (c ConfManager) LoadWithRemote() (*AppConfig, error) {
+	appConf, err := c.LoadOnce()
+	if err != nil {
+		return c.lastKnownGood(), err
+	}
 	k := koanf.New(".") // Create a new koanf instance.
 
 	for _, f := range appConf.Import {
 		//nolint: nestif // no need to nest if
 		if strings.HasPrefix(f, RemoteFilePrefix) {
 			name := strings.TrimPrefix(f, RemoteFilePrefix)
+			if c.storage == nil {
+				return c.lastKnownGood(), errors.Errorf("unable to load remote config %s: storage is not configured", name)
+			}
 			remoteCache, err := (*c.storage).Get([]byte(constant.DeviceRemoteConfigBucket), []byte(name))
 
 			if err != nil {
@@ -128,8 +143,7 @@ func (c ConfManager) LoadWithRemote() *AppConfig {
 			}
 
 			if err := k.Load(rawbytes.Provider(remoteCache), json.Parser()); err != nil {
-				log.Errorf("unable to load remote config: %v", err)
-				continue
+				return c.lastKnownGood(), errors.Wrapf(err, "unable to load remote config %s", name)
 			}
 		} else {
 			localPath := strings.TrimPrefix(f, LocalFilePrefix)
@@ -139,15 +153,41 @@ func (c ConfManager) LoadWithRemote() *AppConfig {
 			}
 
 			if err := k.Load(file.Provider(localPath), yaml.Parser()); err != nil {
-				log.Errorf("unable to load local config: %v", err)
-				continue
+				return c.lastKnownGood(), errors.Wrapf(err, "unable to load local config %s", localPath)
 			}
 		}
 	}
 
-	err := k.Unmarshal("", &appConf)
-	if err != nil {
-		log.Errorf("unable to unmarshal koanf: %v", err)
+	if err := k.Unmarshal("", &appConf); err != nil {
+		return c.lastKnownGood(), errors.Wrap(err, "unable to unmarshal config")
 	}
+
+	c.setLastKnownGood(appConf)
+	return &appConf, nil
+}
+
+func (c ConfManager) setLastKnownGood(appConf AppConfig) {
+	if c.cache == nil {
+		return
+	}
+
+	c.cache.mu.Lock()
+	defer c.cache.mu.Unlock()
+
+	c.cache.lastGood = &appConf
+}
+
+func (c ConfManager) lastKnownGood() *AppConfig {
+	if c.cache == nil {
+		return nil
+	}
+
+	c.cache.mu.RLock()
+	defer c.cache.mu.RUnlock()
+
+	if c.cache.lastGood == nil {
+		return nil
+	}
+	appConf := *c.cache.lastGood
 	return &appConf
 }

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -105,14 +105,27 @@ func (c ConfManager) LoadOnce() (AppConfig, error) {
 
 		localPath := strings.TrimPrefix(f, LocalFilePrefix)
 		if !utils.CheckReadPath(localPath) {
-			log.Warnf("local config file %s not exist", localPath)
-			continue
+			return AppConfig{}, errors.Errorf("unable to load local config %s: file does not exist or is not readable", localPath)
 		}
 
 		if err := utils.ParseYAML(localPath, &appConf); err != nil {
 			return AppConfig{}, errors.Wrapf(err, "unable to load local config %s", localPath)
 		}
 	}
+	return appConf, nil
+}
+
+// LoadStartup loads the local startup configuration and seeds it as an initial
+// fallback. Remote imports are intentionally not required at this stage; the
+// first successful LoadWithRemote replaces this baseline with the complete
+// merged configuration.
+func (c ConfManager) LoadStartup() (AppConfig, error) {
+	appConf, err := c.LoadOnce()
+	if err != nil {
+		return AppConfig{}, err
+	}
+
+	c.setLastKnownGood(appConf)
 	return appConf, nil
 }
 
@@ -127,19 +140,17 @@ func (c ConfManager) LoadWithRemote() (*AppConfig, error) {
 		//nolint: nestif // no need to nest if
 		if strings.HasPrefix(f, RemoteFilePrefix) {
 			name := strings.TrimPrefix(f, RemoteFilePrefix)
-			if c.storage == nil {
+			if c.storage == nil || *c.storage == nil {
 				return c.lastKnownGood(), errors.Errorf("unable to load remote config %s: storage is not configured", name)
 			}
 			remoteCache, err := (*c.storage).Get([]byte(constant.DeviceRemoteConfigBucket), []byte(name))
 
 			if err != nil {
-				log.Errorf("unable to get remote config: %v", err)
-				continue
+				return c.lastKnownGood(), errors.Wrapf(err, "unable to get remote config %s", name)
 			}
 			//nolint: gosimple // no need to simplify
 			if remoteCache == nil || len(remoteCache) == 0 {
-				log.Errorf("remote config is empty")
-				continue
+				return c.lastKnownGood(), errors.Errorf("unable to load remote config %s: config is empty", name)
 			}
 
 			if err := k.Load(rawbytes.Provider(remoteCache), json.Parser()); err != nil {
@@ -148,8 +159,7 @@ func (c ConfManager) LoadWithRemote() (*AppConfig, error) {
 		} else {
 			localPath := strings.TrimPrefix(f, LocalFilePrefix)
 			if !utils.CheckReadPath(localPath) {
-				log.Warnf("file %s not exist or has no permission", localPath)
-				continue
+				return c.lastKnownGood(), errors.Errorf("unable to load local config %s: file does not exist or is not readable", localPath)
 			}
 
 			if err := k.Load(file.Provider(localPath), yaml.Parser()); err != nil {

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,19 +27,30 @@ import (
 )
 
 type configTestStorage struct {
-	value []byte
+	mu     sync.RWMutex
+	value  []byte
+	getErr error
 }
 
 func (s *configTestStorage) Put(_, _, value []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.value = append(s.value[:0], value...)
 	return nil
 }
 
 func (s *configTestStorage) Get(_, _ []byte) ([]byte, error) {
-	return append([]byte(nil), s.value...), nil
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return append([]byte(nil), s.value...), s.getErr
 }
 
 func (s *configTestStorage) Delete(_, _ []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.value = nil
 	return nil
 }
@@ -49,6 +61,20 @@ func (s *configTestStorage) Close() error {
 
 func (s *configTestStorage) Iter(_ []byte, _ func(key, value []byte) error) error {
 	return nil
+}
+
+func (s *configTestStorage) setValue(value []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.value = append(s.value[:0], value...)
+}
+
+func (s *configTestStorage) setGetError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.getErr = err
 }
 
 func TestLoadOnceReturnsInvalidYAMLError(t *testing.T) {
@@ -157,10 +183,97 @@ func TestLoadWithRemoteRejectsInvalidRemoteConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 34567, loaded.HttpServer.Port)
 
-	backend.value = []byte("{")
+	backend.setValue([]byte("{"))
 
 	reloaded, err := manager.LoadWithRemote()
 	require.Error(t, err)
 	require.NotNil(t, reloaded)
 	require.Equal(t, 34567, reloaded.HttpServer.Port)
+}
+
+func TestLoadWithRemoteDoesNotReplaceLastKnownGoodWhenRemoteIsUnavailable(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "cos.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("__import__:\n  - cos://remote\n"), 0o600))
+
+	tests := []struct {
+		name   string
+		update func(*configTestStorage)
+	}{
+		{
+			name: "read error",
+			update: func(backend *configTestStorage) {
+				backend.setGetError(errors.New("storage unavailable"))
+			},
+		},
+		{
+			name: "empty value",
+			update: func(backend *configTestStorage) {
+				backend.setValue(nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &configTestStorage{value: []byte(`{"http_server":{"port":34567}}`)}
+			var store storage.Storage = backend
+			manager := InitConfManager(configPath, &store)
+
+			loaded, err := manager.LoadWithRemote()
+			require.NoError(t, err)
+			require.Equal(t, 34567, loaded.HttpServer.Port)
+
+			tt.update(backend)
+
+			reloaded, err := manager.LoadWithRemote()
+			require.Error(t, err)
+			require.NotNil(t, reloaded)
+			require.Equal(t, 34567, reloaded.HttpServer.Port)
+		})
+	}
+}
+
+func TestLoadWithRemoteDoesNotReplaceLastKnownGoodWhenLocalImportIsMissing(t *testing.T) {
+	configDir := t.TempDir()
+	importPath := filepath.Join(configDir, "import.yaml")
+	configPath := filepath.Join(configDir, "cos.yaml")
+	require.NoError(t, os.WriteFile(importPath, []byte("http_server:\n  port: 23456\n"), 0o600))
+	require.NoError(t, os.WriteFile(
+		configPath,
+		[]byte(fmt.Sprintf("__import__:\n  - file://%s\n", importPath)),
+		0o600,
+	))
+
+	manager := InitConfManager(configPath, nil)
+	loaded, err := manager.LoadWithRemote()
+	require.NoError(t, err)
+	require.Equal(t, 23456, loaded.HttpServer.Port)
+
+	require.NoError(t, os.Remove(importPath))
+
+	reloaded, err := manager.LoadWithRemote()
+	require.Error(t, err)
+	require.NotNil(t, reloaded)
+	require.Equal(t, 23456, reloaded.HttpServer.Port)
+}
+
+func TestLoadStartupSeedsFallbackBeforeRemoteConfigIsAvailable(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "cos.yaml")
+	require.NoError(t, os.WriteFile(
+		configPath,
+		[]byte("http_server:\n  port: 45678\n__import__:\n  - cos://remote\n"),
+		0o600,
+	))
+
+	manager := InitConfManager(configPath, nil)
+	startup, err := manager.LoadStartup()
+	require.NoError(t, err)
+	require.Equal(t, 45678, startup.HttpServer.Port)
+
+	require.NoError(t, os.WriteFile(configPath, []byte("http_server: ["), 0o600))
+
+	reloaded, err := manager.LoadWithRemote()
+	require.Error(t, err)
+	require.NotNil(t, reloaded)
+	require.Equal(t, 45678, reloaded.HttpServer.Port)
 }

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -26,6 +26,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	errReloadUnexpectedlySucceeded = errors.New("reload unexpectedly succeeded")
+	errReloadMissingLastKnownGood  = errors.New("reload returned no last-known-good config")
+	errReloadPortMismatch          = errors.New("reload port mismatch")
+	errStorageUnavailable          = errors.New("storage unavailable")
+)
+
 type configTestStorage struct {
 	mu     sync.RWMutex
 	value  []byte
@@ -78,6 +85,8 @@ func (s *configTestStorage) setGetError(err error) {
 }
 
 func TestLoadOnceReturnsInvalidYAMLError(t *testing.T) {
+	t.Parallel()
+
 	configPath := filepath.Join(t.TempDir(), "cos.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte("http_server: ["), 0o600))
 
@@ -88,6 +97,8 @@ func TestLoadOnceReturnsInvalidYAMLError(t *testing.T) {
 }
 
 func TestLoadWithRemoteReturnsLastKnownGoodOnReloadFailure(t *testing.T) {
+	t.Parallel()
+
 	configPath := filepath.Join(t.TempDir(), "cos.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte("http_server:\n  port: 12345\n"), 0o600))
 
@@ -106,6 +117,8 @@ func TestLoadWithRemoteReturnsLastKnownGoodOnReloadFailure(t *testing.T) {
 }
 
 func TestLoadWithRemoteLastKnownGoodIsConcurrentSafe(t *testing.T) {
+	t.Parallel()
+
 	configPath := filepath.Join(t.TempDir(), "cos.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte("http_server:\n  port: 12345\n"), 0o600))
 
@@ -126,15 +139,15 @@ func TestLoadWithRemoteLastKnownGoodIsConcurrentSafe(t *testing.T) {
 			defer wg.Done()
 			reloaded, loadErr := manager.LoadWithRemote()
 			if loadErr == nil {
-				results <- fmt.Errorf("reload unexpectedly succeeded")
+				results <- errReloadUnexpectedlySucceeded
 				return
 			}
 			if reloaded == nil {
-				results <- fmt.Errorf("reload returned no last-known-good config")
+				results <- errReloadMissingLastKnownGood
 				return
 			}
 			if reloaded.HttpServer.Port != 12345 {
-				results <- fmt.Errorf("reload port = %d, want 12345", reloaded.HttpServer.Port)
+				results <- fmt.Errorf("%w: got %d, want 12345", errReloadPortMismatch, reloaded.HttpServer.Port)
 				return
 			}
 			results <- nil
@@ -148,6 +161,8 @@ func TestLoadWithRemoteLastKnownGoodIsConcurrentSafe(t *testing.T) {
 }
 
 func TestLoadWithRemoteRejectsInvalidImportedConfig(t *testing.T) {
+	t.Parallel()
+
 	configDir := t.TempDir()
 	importPath := filepath.Join(configDir, "import.yaml")
 	configPath := filepath.Join(configDir, "cos.yaml")
@@ -172,6 +187,8 @@ func TestLoadWithRemoteRejectsInvalidImportedConfig(t *testing.T) {
 }
 
 func TestLoadWithRemoteRejectsInvalidRemoteConfig(t *testing.T) {
+	t.Parallel()
+
 	configPath := filepath.Join(t.TempDir(), "cos.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte("__import__:\n  - cos://remote\n"), 0o600))
 
@@ -192,6 +209,8 @@ func TestLoadWithRemoteRejectsInvalidRemoteConfig(t *testing.T) {
 }
 
 func TestLoadWithRemoteDoesNotReplaceLastKnownGoodWhenRemoteIsUnavailable(t *testing.T) {
+	t.Parallel()
+
 	configPath := filepath.Join(t.TempDir(), "cos.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte("__import__:\n  - cos://remote\n"), 0o600))
 
@@ -202,7 +221,7 @@ func TestLoadWithRemoteDoesNotReplaceLastKnownGoodWhenRemoteIsUnavailable(t *tes
 		{
 			name: "read error",
 			update: func(backend *configTestStorage) {
-				backend.setGetError(errors.New("storage unavailable"))
+				backend.setGetError(errStorageUnavailable)
 			},
 		},
 		{
@@ -215,6 +234,8 @@ func TestLoadWithRemoteDoesNotReplaceLastKnownGoodWhenRemoteIsUnavailable(t *tes
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			backend := &configTestStorage{value: []byte(`{"http_server":{"port":34567}}`)}
 			var store storage.Storage = backend
 			manager := InitConfManager(configPath, &store)
@@ -234,6 +255,8 @@ func TestLoadWithRemoteDoesNotReplaceLastKnownGoodWhenRemoteIsUnavailable(t *tes
 }
 
 func TestLoadWithRemoteDoesNotReplaceLastKnownGoodWhenLocalImportIsMissing(t *testing.T) {
+	t.Parallel()
+
 	configDir := t.TempDir()
 	importPath := filepath.Join(configDir, "import.yaml")
 	configPath := filepath.Join(configDir, "cos.yaml")
@@ -258,6 +281,8 @@ func TestLoadWithRemoteDoesNotReplaceLastKnownGoodWhenLocalImportIsMissing(t *te
 }
 
 func TestLoadStartupSeedsFallbackBeforeRemoteConfigIsAvailable(t *testing.T) {
+	t.Parallel()
+
 	configPath := filepath.Join(t.TempDir(), "cos.yaml")
 	require.NoError(t, os.WriteFile(
 		configPath,

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -1,0 +1,166 @@
+// Copyright 2025 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/coscene-io/coscout/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+type configTestStorage struct {
+	value []byte
+}
+
+func (s *configTestStorage) Put(_, _, value []byte) error {
+	s.value = append(s.value[:0], value...)
+	return nil
+}
+
+func (s *configTestStorage) Get(_, _ []byte) ([]byte, error) {
+	return append([]byte(nil), s.value...), nil
+}
+
+func (s *configTestStorage) Delete(_, _ []byte) error {
+	s.value = nil
+	return nil
+}
+
+func (s *configTestStorage) Close() error {
+	return nil
+}
+
+func (s *configTestStorage) Iter(_ []byte, _ func(key, value []byte) error) error {
+	return nil
+}
+
+func TestLoadOnceReturnsInvalidYAMLError(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "cos.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("http_server: ["), 0o600))
+
+	manager := InitConfManager(configPath, nil)
+	_, err := manager.LoadOnce()
+
+	require.Error(t, err)
+}
+
+func TestLoadWithRemoteReturnsLastKnownGoodOnReloadFailure(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "cos.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("http_server:\n  port: 12345\n"), 0o600))
+
+	manager := InitConfManager(configPath, nil)
+	first, err := manager.LoadWithRemote()
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Equal(t, 12345, first.HttpServer.Port)
+
+	require.NoError(t, os.WriteFile(configPath, []byte("http_server: ["), 0o600))
+
+	reloaded, err := manager.LoadWithRemote()
+	require.Error(t, err)
+	require.NotNil(t, reloaded)
+	require.Equal(t, *first, *reloaded)
+}
+
+func TestLoadWithRemoteLastKnownGoodIsConcurrentSafe(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "cos.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("http_server:\n  port: 12345\n"), 0o600))
+
+	manager := InitConfManager(configPath, nil)
+	loaded, err := manager.LoadWithRemote()
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	require.NoError(t, os.WriteFile(configPath, []byte("http_server: ["), 0o600))
+
+	managerCopy := *manager
+	const readers = 20
+	var wg sync.WaitGroup
+	results := make(chan error, readers)
+	wg.Add(readers)
+	for i := range readers {
+		go func(manager ConfManager) {
+			defer wg.Done()
+			reloaded, loadErr := manager.LoadWithRemote()
+			if loadErr == nil {
+				results <- fmt.Errorf("reload unexpectedly succeeded")
+				return
+			}
+			if reloaded == nil {
+				results <- fmt.Errorf("reload returned no last-known-good config")
+				return
+			}
+			if reloaded.HttpServer.Port != 12345 {
+				results <- fmt.Errorf("reload port = %d, want 12345", reloaded.HttpServer.Port)
+				return
+			}
+			results <- nil
+		}([]ConfManager{*manager, managerCopy}[i%2])
+	}
+	wg.Wait()
+	close(results)
+	for result := range results {
+		require.NoError(t, result)
+	}
+}
+
+func TestLoadWithRemoteRejectsInvalidImportedConfig(t *testing.T) {
+	configDir := t.TempDir()
+	importPath := filepath.Join(configDir, "import.yaml")
+	configPath := filepath.Join(configDir, "cos.yaml")
+	require.NoError(t, os.WriteFile(importPath, []byte("http_server:\n  port: 23456\n"), 0o600))
+	require.NoError(t, os.WriteFile(
+		configPath,
+		[]byte(fmt.Sprintf("__import__:\n  - file://%s\n", importPath)),
+		0o600,
+	))
+
+	manager := InitConfManager(configPath, nil)
+	loaded, err := manager.LoadWithRemote()
+	require.NoError(t, err)
+	require.Equal(t, 23456, loaded.HttpServer.Port)
+
+	require.NoError(t, os.WriteFile(importPath, []byte("http_server: ["), 0o600))
+
+	reloaded, err := manager.LoadWithRemote()
+	require.Error(t, err)
+	require.NotNil(t, reloaded)
+	require.Equal(t, 23456, reloaded.HttpServer.Port)
+}
+
+func TestLoadWithRemoteRejectsInvalidRemoteConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "cos.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("__import__:\n  - cos://remote\n"), 0o600))
+
+	backend := &configTestStorage{value: []byte(`{"http_server":{"port":34567}}`)}
+	var store storage.Storage = backend
+	manager := InitConfManager(configPath, &store)
+
+	loaded, err := manager.LoadWithRemote()
+	require.NoError(t, err)
+	require.Equal(t, 34567, loaded.HttpServer.Port)
+
+	backend.value = []byte("{")
+
+	reloaded, err := manager.LoadWithRemote()
+	require.Error(t, err)
+	require.NotNil(t, reloaded)
+	require.Equal(t, 34567, reloaded.HttpServer.Port)
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -32,11 +32,18 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startChan chan bool, finishChan chan bool, errorChan chan error) error {
-	<-startChan
-
-	ctx, cancel := context.WithCancel(context.Background())
+func Run(
+	ctx context.Context,
+	confManager *config.ConfManager,
+	reqClient *api.RequestClient,
+	errorChan chan error,
+) error {
+	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	if runCtx.Err() != nil {
+		return nil
+	}
 
 	appConfig, err := confManager.LoadWithRemote()
 	if err != nil {
@@ -72,35 +79,35 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 	var masterServer *master.Server
 	var masterConfig *config.MasterConfig
 	var fileManager *master.FileManager
+	var masterResult <-chan error
 	if appConfig.MasterSlave.Enabled {
 		masterConfig = config.DefaultMasterConfig()
 		masterServer = master.NewServer(masterConfig.Port, masterConfig)
-		masterStartErr := make(chan error, 1)
+		result := make(chan error, 1)
+		masterResult = result
 		go func() {
-			masterStartErr <- masterServer.Start(ctx)
+			result <- masterServer.Start(runCtx)
 		}()
 
 		select {
 		case <-masterServer.Ready():
-			log.Infof("Master server started on port %d", masterConfig.Port)
-		case err := <-masterStartErr:
-			log.Errorf("Master server failed: %v", err)
-			return err
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-
-		// Continue watching for runtime server failures after startup.
-		go func() {
-			if err := <-masterStartErr; err != nil {
-				log.Errorf("Master server failed: %v", err)
-				select {
-				case errorChan <- err:
-				default:
-					log.Warnf("Error channel is full, dropping error: %v", err)
-				}
+			if runCtx.Err() != nil {
+				err := <-masterResult
+				cancel()
+				return err
 			}
-		}()
+			log.Infof("Master server started on port %d", masterConfig.Port)
+		case err := <-masterResult:
+			if err != nil {
+				log.Errorf("Master server failed: %v", err)
+			}
+			cancel()
+			return err
+		case <-runCtx.Done():
+			err := <-masterResult
+			cancel()
+			return err
+		}
 
 		// Set up FileManager for slave file handling
 		masterClient := master.NewClient(masterConfig)
@@ -110,7 +117,7 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 
 	// Start collector
 	go func() {
-		err := collector.Collect(ctx, reqClient, confManager, fileManager, pubSub, errorChan)
+		err := collector.Collect(runCtx, reqClient, confManager, fileManager, pubSub, errorChan)
 		if err != nil {
 			select {
 			case errorChan <- err:
@@ -130,7 +137,7 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 				ticker.Reset(config.RefreshRemoteConfigInterval)
 				//nolint: contextcheck // context is checked in the parent goroutine
 				refreshRemoteConfig(confManager, reqClient)
-			case <-ctx.Done():
+			case <-runCtx.Done():
 				log.Infof("Daemon ticker goroutine done")
 				return
 			}
@@ -138,7 +145,7 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 	}(ticker)
 
 	// Start core services
-	go core.SendHeartbeat(ctx, reqClient, confManager.GetStorage(), errorChan)
+	go core.SendHeartbeat(runCtx, reqClient, confManager.GetStorage(), errorChan)
 
 	// Start task handler with optional master-slave enhancement
 	taskHandler := mod.NewModHandler(*reqClient, *confManager, pubSub, errorChan, constant.TaskModType)
@@ -150,7 +157,7 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 			log.Info("Task handler enhanced with master-slave support")
 		}
 	}
-	go taskHandler.Run(ctx)
+	go taskHandler.Run(runCtx)
 
 	// Start rule handler with optional master-slave enhancement
 	ruleHandler := mod.NewModHandler(*reqClient, *confManager, pubSub, errorChan, constant.RuleModType)
@@ -162,14 +169,38 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 			log.Info("Rule handler enhanced with master-slave support")
 		}
 	}
-	go ruleHandler.Run(ctx)
+	go ruleHandler.Run(runCtx)
 
 	// Start HTTP handler
-	go mod.NewModHandler(*reqClient, *confManager, pubSub, errorChan, constant.HttpModType).Run(ctx)
+	go mod.NewModHandler(*reqClient, *confManager, pubSub, errorChan, constant.HttpModType).Run(runCtx)
 
 	log.Info("Daemon started successfully")
-	<-finishChan
+	if masterResult != nil {
+		return waitForMasterAndCancel(runCtx, masterResult, cancel)
+	}
+
+	<-runCtx.Done()
+	cancel()
 	return nil
+}
+
+// waitForMasterAndCancel returns a runtime master failure immediately and
+// cancels all other daemon services before returning. On daemon cancellation
+// it still waits for Server.Start to finish shutdown so callers cannot start a
+// replacement daemon before the listening port is released.
+func waitForMasterAndCancel(
+	ctx context.Context,
+	masterResult <-chan error,
+	cancel context.CancelFunc,
+) error {
+	var err error
+	select {
+	case err = <-masterResult:
+	case <-ctx.Done():
+		err = <-masterResult
+	}
+	cancel()
+	return err
 }
 
 func refreshRemoteConfig(confManager *config.ConfManager, reqClient *api.RequestClient) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startChan chan bool, finishChan chan bool, errorChan chan error) {
+func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startChan chan bool, finishChan chan bool, errorChan chan error) error {
 	<-startChan
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -41,12 +41,7 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 	appConfig, err := confManager.LoadWithRemote()
 	if err != nil {
 		if appConfig == nil {
-			select {
-			case errorChan <- err:
-			default:
-				log.Warnf("Error channel is full, dropping error: %v", err)
-			}
-			return
+			return err
 		}
 		log.Warnf("Unable to reload config, continuing with last-known-good config: %v", err)
 	}
@@ -90,14 +85,9 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 			log.Infof("Master server started on port %d", masterConfig.Port)
 		case err := <-masterStartErr:
 			log.Errorf("Master server failed: %v", err)
-			select {
-			case errorChan <- err:
-			default:
-				log.Warnf("Error channel is full, dropping error: %v", err)
-			}
-			return
+			return err
 		case <-ctx.Done():
-			return
+			return ctx.Err()
 		}
 
 		// Continue watching for runtime server failures after startup.
@@ -179,6 +169,7 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 
 	log.Info("Daemon started successfully")
 	<-finishChan
+	return nil
 }
 
 func refreshRemoteConfig(confManager *config.ConfManager, reqClient *api.RequestClient) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -80,8 +80,29 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 	if appConfig.MasterSlave.Enabled {
 		masterConfig = config.DefaultMasterConfig()
 		masterServer = master.NewServer(masterConfig.Port, masterConfig)
+		masterStartErr := make(chan error, 1)
 		go func() {
-			if err := masterServer.Start(ctx); err != nil {
+			masterStartErr <- masterServer.Start(ctx)
+		}()
+
+		select {
+		case <-masterServer.Ready():
+			log.Infof("Master server started on port %d", masterConfig.Port)
+		case err := <-masterStartErr:
+			log.Errorf("Master server failed: %v", err)
+			select {
+			case errorChan <- err:
+			default:
+				log.Warnf("Error channel is full, dropping error: %v", err)
+			}
+			return
+		case <-ctx.Done():
+			return
+		}
+
+		// Continue watching for runtime server failures after startup.
+		go func() {
+			if err := <-masterStartErr; err != nil {
 				log.Errorf("Master server failed: %v", err)
 				select {
 				case errorChan <- err:
@@ -90,7 +111,6 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 				}
 			}
 		}()
-		log.Infof("Master server started on port %d", masterConfig.Port)
 
 		// Set up FileManager for slave file handling
 		masterClient := master.NewClient(masterConfig)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -38,7 +38,18 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	appConfig := confManager.LoadWithRemote()
+	appConfig, err := confManager.LoadWithRemote()
+	if err != nil {
+		if appConfig == nil {
+			select {
+			case errorChan <- err:
+			default:
+				log.Warnf("Error channel is full, dropping error: %v", err)
+			}
+			return
+		}
+		log.Warnf("Unable to reload config, continuing with last-known-good config: %v", err)
+	}
 
 	// Determine mode based on configuration
 	if appConfig.MasterSlave.Enabled {
@@ -151,7 +162,11 @@ func Run(confManager *config.ConfManager, reqClient *api.RequestClient, startCha
 }
 
 func refreshRemoteConfig(confManager *config.ConfManager, reqClient *api.RequestClient) {
-	appConfig := confManager.LoadOnce()
+	appConfig, err := confManager.LoadOnce()
+	if err != nil {
+		log.Errorf("Unable to load local config while refreshing remote config: %v", err)
+		return
+	}
 	if len(appConfig.Import) == 0 {
 		return
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 func TestRunReturnsMasterBindError(t *testing.T) {
+	t.Parallel()
+
+	// #nosec G102 -- this test must reserve every interface used by the daemon.
 	listener, err := net.Listen("tcp", ":22525")
 	if err == nil {
 		t.Cleanup(func() {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,0 +1,65 @@
+// Copyright 2025 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/coscene-io/coscout/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunReturnsMasterBindError(t *testing.T) {
+	listener, err := net.Listen("tcp", ":22525")
+	if err == nil {
+		t.Cleanup(func() {
+			require.NoError(t, listener.Close())
+		})
+	}
+
+	configPath := filepath.Join(t.TempDir(), "cos.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+master_slave:
+  enabled: true
+`), 0o600))
+
+	confManager := config.InitConfManager(configPath, nil)
+	startChan := make(chan bool, 1)
+	finishChan := make(chan bool, 1)
+	errorChan := make(chan error, 1)
+	runErr := make(chan error, 1)
+	startChan <- true
+
+	go func() {
+		runErr <- Run(confManager, nil, startChan, finishChan, errorChan)
+	}()
+
+	select {
+	case err := <-runErr:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return the master bind error")
+	}
+
+	select {
+	case err := <-errorChan:
+		t.Fatalf("startup error was also sent as a non-fatal runtime error: %v", err)
+	default:
+	}
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -15,6 +15,8 @@
 package daemon
 
 import (
+	"context"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -43,14 +45,11 @@ master_slave:
 `), 0o600))
 
 	confManager := config.InitConfManager(configPath, nil)
-	startChan := make(chan bool, 1)
-	finishChan := make(chan bool, 1)
 	errorChan := make(chan error, 1)
 	runErr := make(chan error, 1)
-	startChan <- true
 
 	go func() {
-		runErr <- Run(confManager, nil, startChan, finishChan, errorChan)
+		runErr <- Run(t.Context(), confManager, nil, errorChan)
 	}()
 
 	select {
@@ -64,5 +63,43 @@ master_slave:
 	case err := <-errorChan:
 		t.Fatalf("startup error was also sent as a non-fatal runtime error: %v", err)
 	default:
+	}
+}
+
+func TestWaitForMasterReturnsRuntimeError(t *testing.T) {
+	t.Parallel()
+
+	runtimeErr := errors.New("master serve failed")
+	masterResult := make(chan error, 1)
+	masterResult <- runtimeErr
+	runCtx, cancel := context.WithCancel(t.Context())
+
+	require.ErrorIs(t, waitForMasterAndCancel(runCtx, masterResult, cancel), runtimeErr)
+	require.ErrorIs(t, runCtx.Err(), context.Canceled)
+}
+
+func TestWaitForMasterCancellationWaitsForShutdown(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	masterResult := make(chan error)
+	waitResult := make(chan error, 1)
+	go func() {
+		waitResult <- waitForMasterAndCancel(ctx, masterResult, cancel)
+	}()
+
+	cancel()
+	select {
+	case <-waitResult:
+		t.Fatal("waitForMaster returned before master shutdown completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	masterResult <- nil
+	select {
+	case err := <-waitResult:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("waitForMaster did not return after master shutdown completed")
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var errTestMasterServeFailed = errors.New("master serve failed")
+
 func TestRunReturnsMasterBindError(t *testing.T) {
 	t.Parallel()
 
@@ -69,12 +71,11 @@ master_slave:
 func TestWaitForMasterReturnsRuntimeError(t *testing.T) {
 	t.Parallel()
 
-	runtimeErr := errors.New("master serve failed")
 	masterResult := make(chan error, 1)
-	masterResult <- runtimeErr
+	masterResult <- errTestMasterServeFailed
 	runCtx, cancel := context.WithCancel(t.Context())
 
-	require.ErrorIs(t, waitForMasterAndCancel(runCtx, masterResult, cancel), runtimeErr)
+	require.ErrorIs(t, waitForMasterAndCancel(runCtx, masterResult, cancel), errTestMasterServeFailed)
 	require.ErrorIs(t, runCtx.Err(), context.Canceled)
 }
 

--- a/internal/master/server.go
+++ b/internal/master/server.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coscene-io/coscout/internal/config"
@@ -34,6 +35,9 @@ type Server struct {
 	config   *config.MasterConfig
 	server   *http.Server
 	port     int
+	ready    chan struct{}
+	startMu  sync.Mutex
+	started  bool
 }
 
 // NewServer creates a new master server.
@@ -54,6 +58,7 @@ func NewServer(port int, masterConfig *config.MasterConfig) *Server {
 		config:   masterConfig,
 		server:   server,
 		port:     port,
+		ready:    make(chan struct{}),
 	}
 
 	// Register routes
@@ -66,26 +71,64 @@ func NewServer(port int, masterConfig *config.MasterConfig) *Server {
 	return s
 }
 
+// Ready is closed once the server has successfully bound its listening port.
+func (s *Server) Ready() <-chan struct{} {
+	return s.ready
+}
+
 // Start starts the server.
 func (s *Server) Start(ctx context.Context) error {
-	// Start cleanup goroutine
-	go s.cleanupRoutine(ctx)
+	s.startMu.Lock()
+	if s.started {
+		s.startMu.Unlock()
+		return errors.New("master server already started")
+	}
+	s.started = true
+	s.startMu.Unlock()
 
 	log.Infof("Master server starting on port %d", s.port)
 
-	go func() {
-		if err := s.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Errorf("Master server failed: %v", err)
-		}
-	}()
+	listener, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", s.server.Addr, err)
+	}
+	close(s.ready)
 
-	<-ctx.Done()
-	log.Info("Master server shutting down...")
-
-	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	serverCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	return s.server.Shutdown(shutdownCtx)
+	// Start cleanup only after the listening socket has been acquired.
+	go s.cleanupRoutine(serverCtx)
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- s.server.Serve(listener)
+	}()
+
+	select {
+	case err := <-serveErr:
+		if err == nil || errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return fmt.Errorf("serve master requests: %w", err)
+	case <-ctx.Done():
+		log.Info("Master server shutting down...")
+
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer shutdownCancel()
+
+		if err := s.server.Shutdown(shutdownCtx); err != nil {
+			_ = s.server.Close()
+			<-serveErr
+			return fmt.Errorf("shutdown master server: %w", err)
+		}
+
+		err := <-serveErr
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("serve master requests: %w", err)
+		}
+		return nil
+	}
 }
 
 // GetRegistry returns the slave registry.

--- a/internal/master/server.go
+++ b/internal/master/server.go
@@ -29,6 +29,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var errServerAlreadyStarted = errors.New("master server already started")
+
 // Server master server.
 type Server struct {
 	registry *SlaveRegistry
@@ -81,7 +83,7 @@ func (s *Server) Start(ctx context.Context) error {
 	s.startMu.Lock()
 	if s.started {
 		s.startMu.Unlock()
-		return errors.New("master server already started")
+		return errServerAlreadyStarted
 	}
 	s.started = true
 	s.startMu.Unlock()

--- a/internal/master/server_test.go
+++ b/internal/master/server_test.go
@@ -16,6 +16,7 @@ package master
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -61,7 +62,15 @@ func TestServerStartReturnsBindErrorWithoutReportingReady(t *testing.T) {
 func TestServerStartReportsReadyAfterListenAndStopsOnCancellation(t *testing.T) {
 	t.Parallel()
 
-	server := NewServer(0, config.DefaultMasterConfig())
+	// Reserve a concrete port first so the post-shutdown bind verifies that the
+	// exact listener owned by this server has been released.
+	// #nosec G102 -- this test must reserve every interface used by the server.
+	portReservation, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	port := portReservation.Addr().(*net.TCPAddr).Port
+	require.NoError(t, portReservation.Close())
+
+	server := NewServer(port, config.DefaultMasterConfig())
 	ctx, cancel := context.WithCancel(t.Context())
 	startErr := make(chan error, 1)
 
@@ -80,9 +89,14 @@ func TestServerStartReportsReadyAfterListenAndStopsOnCancellation(t *testing.T) 
 	cancel()
 
 	select {
-	case err := <-startErr:
+	case err = <-startErr:
 		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("Start did not return after cancellation")
 	}
+
+	// #nosec G102 -- this test verifies that shutdown released every interface.
+	rebound, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	require.NoError(t, err, "Start returned before releasing the listening port")
+	require.NoError(t, rebound.Close())
 }

--- a/internal/master/server_test.go
+++ b/internal/master/server_test.go
@@ -67,7 +67,9 @@ func TestServerStartReportsReadyAfterListenAndStopsOnCancellation(t *testing.T) 
 	// #nosec G102 -- this test must reserve every interface used by the server.
 	portReservation, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
-	port := portReservation.Addr().(*net.TCPAddr).Port
+	addr, ok := portReservation.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	port := addr.Port
 	require.NoError(t, portReservation.Close())
 
 	server := NewServer(port, config.DefaultMasterConfig())

--- a/internal/master/server_test.go
+++ b/internal/master/server_test.go
@@ -25,18 +25,23 @@ import (
 )
 
 func TestServerStartReturnsBindErrorWithoutReportingReady(t *testing.T) {
+	t.Parallel()
+
+	// #nosec G102 -- this test must reserve every interface used by the server.
 	listener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, listener.Close())
 	})
 
-	port := listener.Addr().(*net.TCPAddr).Port
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	port := addr.Port
 	server := NewServer(port, config.DefaultMasterConfig())
 
 	startErr := make(chan error, 1)
 	go func() {
-		startErr <- server.Start(context.Background())
+		startErr <- server.Start(t.Context())
 	}()
 
 	select {
@@ -54,8 +59,10 @@ func TestServerStartReturnsBindErrorWithoutReportingReady(t *testing.T) {
 }
 
 func TestServerStartReportsReadyAfterListenAndStopsOnCancellation(t *testing.T) {
+	t.Parallel()
+
 	server := NewServer(0, config.DefaultMasterConfig())
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	startErr := make(chan error, 1)
 
 	go func() {

--- a/internal/master/server_test.go
+++ b/internal/master/server_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package master
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/coscene-io/coscout/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerStartReturnsBindErrorWithoutReportingReady(t *testing.T) {
+	listener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	server := NewServer(port, config.DefaultMasterConfig())
+
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- server.Start(context.Background())
+	}()
+
+	select {
+	case err := <-startErr:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Start did not return the bind error")
+	}
+
+	select {
+	case <-server.Ready():
+		t.Fatal("server reported ready despite the bind error")
+	default:
+	}
+}
+
+func TestServerStartReportsReadyAfterListenAndStopsOnCancellation(t *testing.T) {
+	server := NewServer(0, config.DefaultMasterConfig())
+	ctx, cancel := context.WithCancel(context.Background())
+	startErr := make(chan error, 1)
+
+	go func() {
+		startErr <- server.Start(ctx)
+	}()
+
+	select {
+	case <-server.Ready():
+	case err := <-startErr:
+		t.Fatalf("Start returned before reporting ready: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("server did not report ready after listening")
+	}
+
+	cancel()
+
+	select {
+	case err := <-startErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after cancellation")
+	}
+}

--- a/internal/mod/http/handler.go
+++ b/internal/mod/http/handler.go
@@ -46,7 +46,21 @@ func NewHttpHandler(reqClient api.RequestClient, confManager config.ConfManager,
 }
 
 func (c *CustomHttpHandler) Run(ctx context.Context) {
-	serverPort := c.confManager.LoadWithRemote().HttpServer.Port
+	appConfig, err := c.confManager.LoadWithRemote()
+	if err != nil {
+		if appConfig == nil {
+			log.Errorf("Unable to load HTTP server config: %v", err)
+			select {
+			case c.errChan <- err:
+			case <-ctx.Done():
+			default:
+				log.Warnf("Error channel is unavailable, dropping error: %v", err)
+			}
+			return
+		}
+		log.Warnf("Unable to reload HTTP server config, using last-known-good config: %v", err)
+	}
+	serverPort := appConfig.HttpServer.Port
 
 	router := mux.NewRouter()
 	router.HandleFunc("/ruleEngine/messages", server.RulesHandler(c.pubSub)).Methods("POST")

--- a/internal/mod/http/server/config.go
+++ b/internal/mod/http/server/config.go
@@ -67,7 +67,15 @@ func LogConfigHandler() func(w http.ResponseWriter, r *http.Request) {
 
 func CurrentConfigHandler(confManager config.ConfManager) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		appConfig := confManager.LoadWithRemote()
+		appConfig, loadErr := confManager.LoadWithRemote()
+		if loadErr != nil {
+			if appConfig == nil {
+				log.Errorf("Failed to load current config: %v", loadErr)
+				http.Error(w, loadErr.Error(), http.StatusInternalServerError)
+				return
+			}
+			log.Warnf("Failed to reload current config, serving last-known-good config: %v", loadErr)
+		}
 
 		bytes, err := json.Marshal(appConfig)
 		if err != nil {

--- a/internal/mod/rule/engine.go
+++ b/internal/mod/rule/engine.go
@@ -16,6 +16,7 @@ package rule
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"strconv"
 	"sync"
 	"time"
@@ -51,6 +52,8 @@ type Engine struct {
 	activeTopics mapset.Set[string]
 
 	ruleDebounceTime map[string]*time.Time
+
+	publishCollectInfoFn func(string) error
 }
 
 // UpdateRules updates the rules in the rule engine.
@@ -169,9 +172,10 @@ func (e *Engine) getDeviceName() string {
 	return e.deviceName
 }
 
-// ConsumeNext shows how to process a message through the rule engine.
-func (e *Engine) ConsumeNext(item rule_engine.RuleItem) {
+// ConsumeNext processes a message through the rule engine.
+func (e *Engine) ConsumeNext(item rule_engine.RuleItem) error {
 	log.Debugf("consuming message: %+v", item)
+	var consumeErr error
 
 	e.mu.RLock()
 	rules := e.rules
@@ -225,10 +229,22 @@ func (e *Engine) ConsumeNext(item rule_engine.RuleItem) {
 			for _, action := range rule.Actions {
 				if err := action.Run(curActivation, additionalArgs); err != nil {
 					ruleLog.WithField("action", action.Name).Errorf("failed to run action: %v", err)
+					consumeErr = stderrors.Join(
+						consumeErr,
+						errors.Wrapf(err, "run action %s", action.Name),
+					)
 				}
 			}
-			if err := model.PublishCollectInfo(collectInfoId); err != nil {
+			publishCollectInfo := e.publishCollectInfoFn
+			if publishCollectInfo == nil {
+				publishCollectInfo = model.PublishCollectInfo
+			}
+			if err := publishCollectInfo(collectInfoId); err != nil {
 				ruleLog.Errorf("failed to publish collect info: %v", err)
+				consumeErr = stderrors.Join(
+					consumeErr,
+					errors.Wrap(err, "publish collect info"),
+				)
 			} else {
 				ruleLog.Infof("published collect info")
 			}
@@ -236,6 +252,7 @@ func (e *Engine) ConsumeNext(item rule_engine.RuleItem) {
 	}
 
 	e.cleanupDebounceTime()
+	return consumeErr
 }
 
 func debounceKeyForRule(rule *rule_engine.Rule) string {

--- a/internal/mod/rule/engine_test.go
+++ b/internal/mod/rule/engine_test.go
@@ -25,6 +25,11 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 )
 
+var (
+	errTestActionFailed  = errors.New("action failed")
+	errTestPublishFailed = errors.New("publish failed")
+)
+
 func TestUpdateRulesKeepsAllTopicsActiveWhenAnyRuleHasNoTopic(t *testing.T) {
 	t.Parallel()
 
@@ -106,6 +111,9 @@ func TestConsumeNextDebouncesEachScopeSeparately(t *testing.T) {
 	}
 	engine := Engine{
 		ruleDebounceTime: make(map[string]*time.Time),
+		publishCollectInfoFn: func(string) error {
+			return nil
+		},
 		rules: []*rule_engine.Rule{
 			rule_engine.NewRule(
 				[]rule_engine.Condition{*condition},
@@ -126,8 +134,20 @@ func TestConsumeNextDebouncesEachScopeSeparately(t *testing.T) {
 		},
 	}
 
-	engine.ConsumeNext(rule_engine.RuleItem{Msg: map[string]interface{}{"code": "A"}, Topic: "/fault", Ts: 1})
-	engine.ConsumeNext(rule_engine.RuleItem{Msg: map[string]interface{}{"code": "B"}, Topic: "/fault", Ts: 2})
+	if err := engine.ConsumeNext(rule_engine.RuleItem{
+		Msg:   map[string]interface{}{"code": "A"},
+		Topic: "/fault",
+		Ts:    1,
+	}); err != nil {
+		t.Fatalf("consume scope A: %v", err)
+	}
+	if err := engine.ConsumeNext(rule_engine.RuleItem{
+		Msg:   map[string]interface{}{"code": "B"},
+		Topic: "/fault",
+		Ts:    2,
+	}); err != nil {
+		t.Fatalf("consume scope B: %v", err)
+	}
 
 	if len(triggered) != 2 {
 		t.Fatalf("triggered scopes = %v, want both scopes to trigger independently", triggered)
@@ -140,12 +160,11 @@ func TestConsumeNextDebouncesEachScopeSeparately(t *testing.T) {
 func TestConsumeNextReturnsActionError(t *testing.T) {
 	t.Parallel()
 
-	actionErr := errors.New("action failed")
 	action, err := rule_engine.NewAction(
 		"failing-action",
 		map[string]interface{}{},
 		func(map[string]interface{}) error {
-			return actionErr
+			return errTestActionFailed
 		},
 	)
 	if err != nil {
@@ -167,7 +186,7 @@ func TestConsumeNextReturnsActionError(t *testing.T) {
 		Ts:    1,
 	})
 
-	if !errors.Is(gotErr, actionErr) {
+	if !errors.Is(gotErr, errTestActionFailed) {
 		t.Fatalf("ConsumeNext error = %v, want action error", gotErr)
 	}
 	if publishCalls != 1 {
@@ -186,12 +205,11 @@ func TestConsumeNextReturnsPublishError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new action: %v", err)
 	}
-	publishErr := errors.New("publish failed")
 	engine := Engine{
 		rules:            []*rule_engine.Rule{testRuntimeRule(t, action)},
 		ruleDebounceTime: make(map[string]*time.Time),
 		publishCollectInfoFn: func(string) error {
-			return publishErr
+			return errTestPublishFailed
 		},
 	}
 
@@ -201,7 +219,7 @@ func TestConsumeNextReturnsPublishError(t *testing.T) {
 		Ts:    1,
 	})
 
-	if !errors.Is(gotErr, publishErr) {
+	if !errors.Is(gotErr, errTestPublishFailed) {
 		t.Fatalf("ConsumeNext error = %v, want publish error", gotErr)
 	}
 }

--- a/internal/mod/rule/engine_test.go
+++ b/internal/mod/rule/engine_test.go
@@ -15,6 +15,7 @@
 package rule
 
 import (
+	"errors"
 	"slices"
 	"testing"
 	"time"
@@ -134,6 +135,95 @@ func TestConsumeNextDebouncesEachScopeSeparately(t *testing.T) {
 	if triggered[0] != "A" || triggered[1] != "B" {
 		t.Fatalf("triggered scopes = %v, want [A B]", triggered)
 	}
+}
+
+func TestConsumeNextReturnsActionError(t *testing.T) {
+	t.Parallel()
+
+	actionErr := errors.New("action failed")
+	action, err := rule_engine.NewAction(
+		"failing-action",
+		map[string]interface{}{},
+		func(map[string]interface{}) error {
+			return actionErr
+		},
+	)
+	if err != nil {
+		t.Fatalf("new action: %v", err)
+	}
+	publishCalls := 0
+	engine := Engine{
+		rules:            []*rule_engine.Rule{testRuntimeRule(t, action)},
+		ruleDebounceTime: make(map[string]*time.Time),
+		publishCollectInfoFn: func(string) error {
+			publishCalls++
+			return nil
+		},
+	}
+
+	gotErr := engine.ConsumeNext(rule_engine.RuleItem{
+		Msg:   map[string]interface{}{},
+		Topic: "/fault",
+		Ts:    1,
+	})
+
+	if !errors.Is(gotErr, actionErr) {
+		t.Fatalf("ConsumeNext error = %v, want action error", gotErr)
+	}
+	if publishCalls != 1 {
+		t.Fatalf("publish calls = %d, want 1", publishCalls)
+	}
+}
+
+func TestConsumeNextReturnsPublishError(t *testing.T) {
+	t.Parallel()
+
+	action, err := rule_engine.NewAction(
+		"successful-action",
+		map[string]interface{}{},
+		rule_engine.EmptyActionImpl,
+	)
+	if err != nil {
+		t.Fatalf("new action: %v", err)
+	}
+	publishErr := errors.New("publish failed")
+	engine := Engine{
+		rules:            []*rule_engine.Rule{testRuntimeRule(t, action)},
+		ruleDebounceTime: make(map[string]*time.Time),
+		publishCollectInfoFn: func(string) error {
+			return publishErr
+		},
+	}
+
+	gotErr := engine.ConsumeNext(rule_engine.RuleItem{
+		Msg:   map[string]interface{}{},
+		Topic: "/fault",
+		Ts:    1,
+	})
+
+	if !errors.Is(gotErr, publishErr) {
+		t.Fatalf("ConsumeNext error = %v, want publish error", gotErr)
+	}
+}
+
+func testRuntimeRule(t *testing.T, action *rule_engine.Action) *rule_engine.Rule {
+	t.Helper()
+
+	condition, err := rule_engine.NewCondition("true")
+	if err != nil {
+		t.Fatalf("new condition: %v", err)
+	}
+	return rule_engine.NewRule(
+		[]rule_engine.Condition{*condition},
+		[]rule_engine.Action{*action},
+		nil,
+		mapset.NewSet[string]("/fault"),
+		0,
+		map[string]interface{}{
+			"rule_name":         "runtime-rule",
+			"rule_display_name": "runtime rule",
+		},
+	)
 }
 
 func testDiagnosisRule(id string, activeTopic string) *resources.DiagnosisRule {

--- a/internal/mod/rule/file_handlers/cancellation_test.go
+++ b/internal/mod/rule/file_handlers/cancellation_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file_handlers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/coscene-io/coscout/pkg/rule_engine"
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogHandlerCancellationUnblocksFullRuleItemChannel(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "application.log")
+	require.NoError(t, os.WriteFile(
+		logPath,
+		[]byte("2025-01-01 00:00:00.000 INFO started\n"),
+		0o600,
+	))
+
+	ruleItems := make(chan rule_engine.RuleItem)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		NewLogHandler().SendRuleItems(ctx, logPath, mapset.NewSet[string](), ruleItems)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("log handler returned before its blocked channel send was cancelled")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}

--- a/internal/mod/rule/file_handlers/cancellation_test.go
+++ b/internal/mod/rule/file_handlers/cancellation_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestLogHandlerCancellationUnblocksFullRuleItemChannel(t *testing.T) {
+	t.Parallel()
+
 	logPath := filepath.Join(t.TempDir(), "application.log")
 	require.NoError(t, os.WriteFile(
 		logPath,
@@ -35,7 +37,7 @@ func TestLogHandlerCancellationUnblocksFullRuleItemChannel(t *testing.T) {
 	))
 
 	ruleItems := make(chan rule_engine.RuleItem)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	done := make(chan struct{})
 	result := make(chan error, 1)
@@ -73,6 +75,8 @@ func TestLogHandlerCancellationUnblocksFullRuleItemChannel(t *testing.T) {
 }
 
 func TestHandlersReturnErrorsForUnreadableFiles(t *testing.T) {
+	t.Parallel()
+
 	missingPath := filepath.Join(t.TempDir(), "missing")
 	ruleItems := make(chan rule_engine.RuleItem, 1)
 	activeTopics := mapset.NewSet[string]()
@@ -83,8 +87,10 @@ func TestHandlersReturnErrorsForUnreadableFiles(t *testing.T) {
 		"ros1": NewRos1Handler(),
 	} {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			err := handler.SendRuleItems(
-				context.Background(),
+				t.Context(),
 				missingPath,
 				activeTopics,
 				ruleItems,
@@ -95,16 +101,18 @@ func TestHandlersReturnErrorsForUnreadableFiles(t *testing.T) {
 }
 
 func TestIntentionalSkipsReturnSuccess(t *testing.T) {
+	t.Parallel()
+
 	ruleItems := make(chan rule_engine.RuleItem, 1)
 
 	require.NoError(t, NewDefaultHandler().SendRuleItems(
-		context.Background(),
+		t.Context(),
 		"unsupported.file",
 		mapset.NewSet[string](),
 		ruleItems,
 	))
 	require.NoError(t, NewLogHandler().SendRuleItems(
-		context.Background(),
+		t.Context(),
 		"missing.log",
 		mapset.NewSet[string]("/some_other_topic"),
 		ruleItems,
@@ -112,6 +120,8 @@ func TestIntentionalSkipsReturnSuccess(t *testing.T) {
 }
 
 func TestLogHandlerEOFReturnsSuccess(t *testing.T) {
+	t.Parallel()
+
 	logPath := filepath.Join(t.TempDir(), "application.log")
 	require.NoError(t, os.WriteFile(
 		logPath,
@@ -121,7 +131,7 @@ func TestLogHandlerEOFReturnsSuccess(t *testing.T) {
 	ruleItems := make(chan rule_engine.RuleItem, 1)
 
 	require.NoError(t, NewLogHandler().SendRuleItems(
-		context.Background(),
+		t.Context(),
 		logPath,
 		mapset.NewSet[string](),
 		ruleItems,

--- a/internal/mod/rule/file_handlers/cancellation_test.go
+++ b/internal/mod/rule/file_handlers/cancellation_test.go
@@ -36,10 +36,17 @@ func TestLogHandlerCancellationUnblocksFullRuleItemChannel(t *testing.T) {
 
 	ruleItems := make(chan rule_engine.RuleItem)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	done := make(chan struct{})
+	result := make(chan error, 1)
 	go func() {
 		defer close(done)
-		NewLogHandler().SendRuleItems(ctx, logPath, mapset.NewSet[string](), ruleItems)
+		result <- NewLogHandler().SendRuleItems(
+			ctx,
+			logPath,
+			mapset.NewSet[string](),
+			ruleItems,
+		)
 	}()
 
 	select {
@@ -49,6 +56,12 @@ func TestLogHandlerCancellationUnblocksFullRuleItemChannel(t *testing.T) {
 	}
 
 	cancel()
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("log handler did not return after cancellation")
+	}
 	require.Eventually(t, func() bool {
 		select {
 		case <-done:
@@ -57,4 +70,61 @@ func TestLogHandlerCancellationUnblocksFullRuleItemChannel(t *testing.T) {
 			return false
 		}
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestHandlersReturnErrorsForUnreadableFiles(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing")
+	ruleItems := make(chan rule_engine.RuleItem, 1)
+	activeTopics := mapset.NewSet[string]()
+
+	for name, handler := range map[string]Interface{
+		"log":  NewLogHandler(),
+		"mcap": NewMcapHandler(),
+		"ros1": NewRos1Handler(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := handler.SendRuleItems(
+				context.Background(),
+				missingPath,
+				activeTopics,
+				ruleItems,
+			)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestIntentionalSkipsReturnSuccess(t *testing.T) {
+	ruleItems := make(chan rule_engine.RuleItem, 1)
+
+	require.NoError(t, NewDefaultHandler().SendRuleItems(
+		context.Background(),
+		"unsupported.file",
+		mapset.NewSet[string](),
+		ruleItems,
+	))
+	require.NoError(t, NewLogHandler().SendRuleItems(
+		context.Background(),
+		"missing.log",
+		mapset.NewSet[string]("/some_other_topic"),
+		ruleItems,
+	))
+}
+
+func TestLogHandlerEOFReturnsSuccess(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "application.log")
+	require.NoError(t, os.WriteFile(
+		logPath,
+		[]byte("2025-01-01 00:00:00.000 INFO complete\n"),
+		0o600,
+	))
+	ruleItems := make(chan rule_engine.RuleItem, 1)
+
+	require.NoError(t, NewLogHandler().SendRuleItems(
+		context.Background(),
+		logPath,
+		mapset.NewSet[string](),
+		ruleItems,
+	))
+	require.Len(t, ruleItems, 1)
 }

--- a/internal/mod/rule/file_handlers/default.go
+++ b/internal/mod/rule/file_handlers/default.go
@@ -75,8 +75,9 @@ func (h *defaultHandler) SendRuleItems(
 	filePath string,
 	_ mapset.Set[string],
 	_ chan<- rule_engine.RuleItem,
-) {
+) error {
 	log.Info("filePath not supported by rule engine: ", filePath, ", skip sending rule items")
+	return nil
 }
 
 func (h *defaultHandler) IsFinished(filePath string) bool {

--- a/internal/mod/rule/file_handlers/default.go
+++ b/internal/mod/rule/file_handlers/default.go
@@ -15,6 +15,7 @@
 package file_handlers
 
 import (
+	"context"
 	"os"
 	"strings"
 	"time"
@@ -69,7 +70,12 @@ func (h *defaultHandler) GetStartTimeEndTime(filePath string) (*time.Time, *time
 	return &birthTime, &modTime, nil
 }
 
-func (h *defaultHandler) SendRuleItems(filePath string, activeTopics mapset.Set[string], ruleItemChan chan rule_engine.RuleItem) {
+func (h *defaultHandler) SendRuleItems(
+	_ context.Context,
+	filePath string,
+	_ mapset.Set[string],
+	_ chan<- rule_engine.RuleItem,
+) {
 	log.Info("filePath not supported by rule engine: ", filePath, ", skip sending rule items")
 }
 

--- a/internal/mod/rule/file_handlers/interface.go
+++ b/internal/mod/rule/file_handlers/interface.go
@@ -15,6 +15,7 @@
 package file_handlers
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -37,7 +38,25 @@ type Interface interface {
 	IsFinished(filePath string) bool
 
 	// SendRuleItems sends rule items to the rule engine.
-	SendRuleItems(filePath string, activeTopics mapset.Set[string], ruleItemChan chan rule_engine.RuleItem)
+	SendRuleItems(
+		ctx context.Context,
+		filePath string,
+		activeTopics mapset.Set[string],
+		ruleItemChan chan<- rule_engine.RuleItem,
+	)
+}
+
+func sendRuleItem(
+	ctx context.Context,
+	ruleItemChan chan<- rule_engine.RuleItem,
+	item rule_engine.RuleItem,
+) bool {
+	select {
+	case ruleItemChan <- item:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // defaultGetFileSize provides default implementations for some methods.

--- a/internal/mod/rule/file_handlers/interface.go
+++ b/internal/mod/rule/file_handlers/interface.go
@@ -37,25 +37,26 @@ type Interface interface {
 	// IsFinished checks if the file is completely written and no more updates are expected.
 	IsFinished(filePath string) bool
 
-	// SendRuleItems sends rule items to the rule engine.
+	// SendRuleItems sends rule items to the rule engine. It returns nil only
+	// after the file is fully handled or intentionally skipped.
 	SendRuleItems(
 		ctx context.Context,
 		filePath string,
 		activeTopics mapset.Set[string],
 		ruleItemChan chan<- rule_engine.RuleItem,
-	)
+	) error
 }
 
 func sendRuleItem(
 	ctx context.Context,
 	ruleItemChan chan<- rule_engine.RuleItem,
 	item rule_engine.RuleItem,
-) bool {
+) error {
 	select {
 	case ruleItemChan <- item:
-		return true
+		return nil
 	case <-ctx.Done():
-		return false
+		return ctx.Err()
 	}
 }
 

--- a/internal/mod/rule/file_handlers/log.go
+++ b/internal/mod/rule/file_handlers/log.go
@@ -81,46 +81,46 @@ func (h *logHandler) SendRuleItems(
 	filePath string,
 	activeTopics mapset.Set[string],
 	ruleItemChan chan<- rule_engine.RuleItem,
-) {
+) error {
 	if activeTopics.Cardinality() > 0 && !activeTopics.Contains("/external_log") {
-		return
+		return nil
 	}
 
 	logFileReader, err := os.Open(filePath)
 	if err != nil {
 		log.Errorf("open log file [%s] failed: %v", filePath, err)
-		return
+		return errors.Errorf("open log file [%s]: %v", filePath, err)
 	}
 	defer logFileReader.Close()
 
 	reader, err := log_reader.NewLogReader(logFileReader, filePath)
 	if err != nil {
 		log.Errorf("failed to create log reader for log file %s: %v", filePath, err)
-		return
+		return errors.Errorf("create log reader for log file %s: %v", filePath, err)
 	}
 
 	iter, err := log_reader.NewLogIterator(reader)
 	if err != nil {
 		log.Errorf("failed to create log iterator for log file %s: %v", filePath, err)
-		return
+		return errors.Errorf("create log iterator for log file %s: %v", filePath, err)
 	}
 
 	for {
 		if ctx.Err() != nil {
-			return
+			return ctx.Err()
 		}
 
 		stampedLog, hasNext := iter.Next()
 		if !hasNext {
 			log.Infof("finished sending rule items for log file %s", filePath)
-			break
+			return nil
 		}
 
 		sec := stampedLog.Timestamp.Unix()
 		nsec := stampedLog.Timestamp.Nanosecond()
 		tsFloat := float64(sec) + float64(nsec)/1e9
 
-		if !sendRuleItem(ctx, ruleItemChan, rule_engine.RuleItem{
+		if err := sendRuleItem(ctx, ruleItemChan, rule_engine.RuleItem{
 			Msg: map[string]interface{}{
 				"timestamp": map[string]interface{}{
 					"sec":  sec,
@@ -133,8 +133,8 @@ func (h *logHandler) SendRuleItems(
 			Topic:  "/external_log",
 			Ts:     tsFloat,
 			Source: filePath,
-		}) {
-			return
+		}); err != nil {
+			return err
 		}
 	}
 }

--- a/internal/mod/rule/file_handlers/log.go
+++ b/internal/mod/rule/file_handlers/log.go
@@ -15,6 +15,7 @@
 package file_handlers
 
 import (
+	"context"
 	"os"
 	"strings"
 	"time"
@@ -75,7 +76,12 @@ func (h *logHandler) GetStartTimeEndTime(filePath string) (*time.Time, *time.Tim
 	return startTime, endTime, nil
 }
 
-func (h *logHandler) SendRuleItems(filePath string, activeTopics mapset.Set[string], ruleItemChan chan rule_engine.RuleItem) {
+func (h *logHandler) SendRuleItems(
+	ctx context.Context,
+	filePath string,
+	activeTopics mapset.Set[string],
+	ruleItemChan chan<- rule_engine.RuleItem,
+) {
 	if activeTopics.Cardinality() > 0 && !activeTopics.Contains("/external_log") {
 		return
 	}
@@ -100,6 +106,10 @@ func (h *logHandler) SendRuleItems(filePath string, activeTopics mapset.Set[stri
 	}
 
 	for {
+		if ctx.Err() != nil {
+			return
+		}
+
 		stampedLog, hasNext := iter.Next()
 		if !hasNext {
 			log.Infof("finished sending rule items for log file %s", filePath)
@@ -110,7 +120,7 @@ func (h *logHandler) SendRuleItems(filePath string, activeTopics mapset.Set[stri
 		nsec := stampedLog.Timestamp.Nanosecond()
 		tsFloat := float64(sec) + float64(nsec)/1e9
 
-		ruleItemChan <- rule_engine.RuleItem{
+		if !sendRuleItem(ctx, ruleItemChan, rule_engine.RuleItem{
 			Msg: map[string]interface{}{
 				"timestamp": map[string]interface{}{
 					"sec":  sec,
@@ -123,6 +133,8 @@ func (h *logHandler) SendRuleItems(filePath string, activeTopics mapset.Set[stri
 			Topic:  "/external_log",
 			Ts:     tsFloat,
 			Source: filePath,
+		}) {
+			return
 		}
 	}
 }

--- a/internal/mod/rule/file_handlers/mcap.go
+++ b/internal/mod/rule/file_handlers/mcap.go
@@ -223,12 +223,8 @@ func (h *mcapHandler) SendRuleItems(
 	ros2Decoders := make(map[string]mcap_ros2.DecoderFunction)
 	descriptors := make(map[uint16]protoreflect.MessageDescriptor)
 	errTopics := map[string]struct{}{}
-	var processingErr error
-	recordProcessingError := func(err error) {
+	logMessageError := func(err error) {
 		log.Error(err)
-		if processingErr == nil {
-			processingErr = err
-		}
 	}
 
 	for {
@@ -240,7 +236,7 @@ func (h *mcapHandler) SendRuleItems(
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				log.Infof("finished sending rule items for MCAP file %s", filepath)
-				return processingErr
+				return nil
 			} else {
 				log.Errorf("error reading message: %v", err)
 				return errors.Errorf("read MCAP message: %v", err)
@@ -259,11 +255,11 @@ func (h *mcapHandler) SendRuleItems(
 			switch channel.MessageEncoding {
 			case "json":
 				if err := json.Unmarshal(message.Data, &decoded); err != nil {
-					recordProcessingError(errors.Errorf("unmarshal JSON: %v", err))
+					logMessageError(errors.Errorf("unmarshal JSON: %v", err))
 					continue
 				}
 			default:
-				recordProcessingError(errors.Errorf(
+				logMessageError(errors.Errorf(
 					"unsupported message encoding for schema-less channel: %s",
 					channel.MessageEncoding,
 				))
@@ -277,7 +273,7 @@ func (h *mcapHandler) SendRuleItems(
 					packageName := strings.Split(schema.Name, "/")[0]
 					transcoder, err = ros1msg.NewJSONTranscoder(packageName, schema.Data)
 					if err != nil {
-						recordProcessingError(errors.Errorf("create JSON transcoder: %v", err))
+						logMessageError(errors.Errorf("create JSON transcoder: %v", err))
 						continue
 					}
 					transcoders[channel.SchemaID] = transcoder
@@ -286,11 +282,11 @@ func (h *mcapHandler) SendRuleItems(
 				buf := &bytes.Buffer{}
 				msgReader.Reset(message.Data)
 				if err := transcoder.Transcode(buf, msgReader); err != nil {
-					recordProcessingError(errors.Errorf("transcode ros1 message: %v", err))
+					logMessageError(errors.Errorf("transcode ros1 message: %v", err))
 					continue
 				}
 				if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
-					recordProcessingError(errors.Errorf("unmarshal transcoded data: %v", err))
+					logMessageError(errors.Errorf("unmarshal transcoded data: %v", err))
 					continue
 				}
 
@@ -299,7 +295,7 @@ func (h *mcapHandler) SendRuleItems(
 				if !ok {
 					dynamicDecoders, err := mcap_ros2.GenerateDynamic(schema.Name, string(schema.Data))
 					if err != nil {
-						recordProcessingError(errors.Errorf("generate dynamic schema decoder: %v", err))
+						logMessageError(errors.Errorf("generate dynamic schema decoder: %v", err))
 						continue
 					}
 
@@ -310,7 +306,7 @@ func (h *mcapHandler) SendRuleItems(
 					var decoderOk bool
 					decoder, decoderOk = dynamicDecoders[schema.Name]
 					if !decoderOk {
-						recordProcessingError(errors.Errorf("find decoder for schema: %s", schema.Name))
+						logMessageError(errors.Errorf("find decoder for schema: %s", schema.Name))
 						continue
 					}
 				}
@@ -326,11 +322,11 @@ func (h *mcapHandler) SendRuleItems(
 					decoded, err = decoder(message.Data)
 				}()
 				if panicErr != nil {
-					recordProcessingError(errors.Errorf("decode message: %v", panicErr))
+					logMessageError(errors.Errorf("decode message: %v", panicErr))
 					continue
 				}
 				if err != nil {
-					recordProcessingError(errors.Errorf("decode message: %v", err))
+					logMessageError(errors.Errorf("decode message: %v", err))
 					continue
 				}
 
@@ -339,23 +335,23 @@ func (h *mcapHandler) SendRuleItems(
 				if !ok {
 					fileDescriptorSet := &descriptorpb.FileDescriptorSet{}
 					if err := proto.Unmarshal(schema.Data, fileDescriptorSet); err != nil {
-						recordProcessingError(errors.Errorf("build file descriptor set: %v", err))
+						logMessageError(errors.Errorf("build file descriptor set: %v", err))
 						continue
 					}
 					files, err := protodesc.FileOptions{}.NewFiles(fileDescriptorSet)
 					if err != nil {
-						recordProcessingError(errors.Errorf("create file descriptor: %v", err))
+						logMessageError(errors.Errorf("create file descriptor: %v", err))
 						continue
 					}
 					descriptor, err := files.FindDescriptorByName(protoreflect.FullName(schema.Name))
 					if err != nil {
-						recordProcessingError(errors.Errorf("find descriptor: %v", err))
+						logMessageError(errors.Errorf("find descriptor: %v", err))
 						continue
 					}
 					var descriptorOk bool
 					messageDescriptor, descriptorOk = descriptor.(protoreflect.MessageDescriptor)
 					if !descriptorOk {
-						recordProcessingError(errors.Errorf(
+						logMessageError(errors.Errorf(
 							"descriptor %s is not a message descriptor",
 							schema.Name,
 						))
@@ -365,27 +361,27 @@ func (h *mcapHandler) SendRuleItems(
 				}
 				protoMsg := dynamicpb.NewMessage(messageDescriptor)
 				if err := proto.Unmarshal(message.Data, protoMsg); err != nil {
-					recordProcessingError(errors.Errorf("parse protobuf message: %v", err))
+					logMessageError(errors.Errorf("parse protobuf message: %v", err))
 					continue
 				}
 				marshalledBytes, err := protojson.Marshal(protoMsg)
 				if err != nil {
-					recordProcessingError(errors.Errorf("marshal protobuf to JSON: %v", err))
+					logMessageError(errors.Errorf("marshal protobuf to JSON: %v", err))
 					continue
 				}
 				if err := json.Unmarshal(marshalledBytes, &decoded); err != nil {
-					recordProcessingError(errors.Errorf("unmarshal protobuf JSON: %v", err))
+					logMessageError(errors.Errorf("unmarshal protobuf JSON: %v", err))
 					continue
 				}
 
 			case "jsonschema":
 				if err := json.Unmarshal(message.Data, &decoded); err != nil {
-					recordProcessingError(errors.Errorf("unmarshal JSON schema message: %v", err))
+					logMessageError(errors.Errorf("unmarshal JSON schema message: %v", err))
 					continue
 				}
 
 			default:
-				recordProcessingError(errors.Errorf("unsupported schema encoding: %s", schema.Encoding))
+				logMessageError(errors.Errorf("unsupported schema encoding: %s", schema.Encoding))
 				continue
 			}
 		}

--- a/internal/mod/rule/file_handlers/mcap.go
+++ b/internal/mod/rule/file_handlers/mcap.go
@@ -172,25 +172,25 @@ func (h *mcapHandler) SendRuleItems(
 	filepath string,
 	activeTopics mapset.Set[string],
 	ruleItemChan chan<- rule_engine.RuleItem,
-) {
+) error {
 	file, err := os.Open(filepath)
 	if err != nil {
 		log.Errorf("failed to open MCAP file [%s]: %v", filepath, err)
-		return
+		return errors.Errorf("open MCAP file [%s]: %v", filepath, err)
 	}
 	defer file.Close()
 
 	reader, err := mcap.NewReader(file)
 	if err != nil {
 		log.Errorf("failed to create MCAP reader: %v", err)
-		return
+		return errors.Errorf("create MCAP reader: %v", err)
 	}
 	defer reader.Close()
 
 	info, err := reader.Info()
 	if err != nil {
 		log.Errorf("failed to get info for MCAP file [%s]: %v", filepath, err)
-		return
+		return errors.Errorf("get info for MCAP file [%s]: %v", filepath, err)
 	}
 
 	// targetTopics will be empty if no active topics are provided
@@ -205,7 +205,7 @@ func (h *mcapHandler) SendRuleItems(
 
 		if targetTopics.Cardinality() == 0 {
 			log.Infof("no active topics found in MCAP file %s", filepath)
-			return
+			return nil
 		}
 	}
 	log.Infof("sending rule items for MCAP file %s with topics: %v", filepath, targetTopics)
@@ -213,7 +213,7 @@ func (h *mcapHandler) SendRuleItems(
 	iter, err := reader.Messages(mcap.WithTopics(targetTopics.ToSlice()))
 	if err != nil {
 		log.Errorf("failed to create message iterator: %v", err)
-		return
+		return errors.Errorf("create MCAP message iterator: %v", err)
 	}
 
 	// Remove msgBuf since we'll decode directly to map where possible
@@ -223,20 +223,28 @@ func (h *mcapHandler) SendRuleItems(
 	ros2Decoders := make(map[string]mcap_ros2.DecoderFunction)
 	descriptors := make(map[uint16]protoreflect.MessageDescriptor)
 	errTopics := map[string]struct{}{}
+	var processingErr error
+	recordProcessingError := func(err error) {
+		log.Error(err)
+		if processingErr == nil {
+			processingErr = err
+		}
+	}
 
 	for {
 		if ctx.Err() != nil {
-			return
+			return ctx.Err()
 		}
 
 		schema, channel, message, err := iter.NextInto(msg)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				log.Infof("finished sending rule items for MCAP file %s", filepath)
+				return processingErr
 			} else {
 				log.Errorf("error reading message: %v", err)
+				return errors.Errorf("read MCAP message: %v", err)
 			}
-			return
 		}
 
 		if _, ok := errTopics[channel.Topic]; ok {
@@ -251,11 +259,14 @@ func (h *mcapHandler) SendRuleItems(
 			switch channel.MessageEncoding {
 			case "json":
 				if err := json.Unmarshal(message.Data, &decoded); err != nil {
-					log.Errorf("failed to unmarshal JSON: %v", err)
+					recordProcessingError(errors.Errorf("unmarshal JSON: %v", err))
 					continue
 				}
 			default:
-				log.Errorf("unsupported message encoding for schema-less channel: %s", channel.MessageEncoding)
+				recordProcessingError(errors.Errorf(
+					"unsupported message encoding for schema-less channel: %s",
+					channel.MessageEncoding,
+				))
 				continue
 			}
 		} else {
@@ -266,7 +277,7 @@ func (h *mcapHandler) SendRuleItems(
 					packageName := strings.Split(schema.Name, "/")[0]
 					transcoder, err = ros1msg.NewJSONTranscoder(packageName, schema.Data)
 					if err != nil {
-						log.Errorf("failed to create JSON transcoder: %v", err)
+						recordProcessingError(errors.Errorf("create JSON transcoder: %v", err))
 						continue
 					}
 					transcoders[channel.SchemaID] = transcoder
@@ -275,11 +286,11 @@ func (h *mcapHandler) SendRuleItems(
 				buf := &bytes.Buffer{}
 				msgReader.Reset(message.Data)
 				if err := transcoder.Transcode(buf, msgReader); err != nil {
-					log.Errorf("failed to transcode: %v", err)
+					recordProcessingError(errors.Errorf("transcode ros1 message: %v", err))
 					continue
 				}
 				if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
-					log.Errorf("failed to unmarshal transcoded data: %v", err)
+					recordProcessingError(errors.Errorf("unmarshal transcoded data: %v", err))
 					continue
 				}
 
@@ -288,7 +299,7 @@ func (h *mcapHandler) SendRuleItems(
 				if !ok {
 					dynamicDecoders, err := mcap_ros2.GenerateDynamic(schema.Name, string(schema.Data))
 					if err != nil {
-						log.Errorf("failed to generate dynamic schema decoder: %v", err)
+						recordProcessingError(errors.Errorf("generate dynamic schema decoder: %v", err))
 						continue
 					}
 
@@ -299,7 +310,7 @@ func (h *mcapHandler) SendRuleItems(
 					var decoderOk bool
 					decoder, decoderOk = dynamicDecoders[schema.Name]
 					if !decoderOk {
-						log.Errorf("failed to find decoder for schema: %s", schema.Name)
+						recordProcessingError(errors.Errorf("find decoder for schema: %s", schema.Name))
 						continue
 					}
 				}
@@ -315,7 +326,11 @@ func (h *mcapHandler) SendRuleItems(
 					decoded, err = decoder(message.Data)
 				}()
 				if panicErr != nil {
-					log.Errorf("failed to decode message: %v", panicErr)
+					recordProcessingError(errors.Errorf("decode message: %v", panicErr))
+					continue
+				}
+				if err != nil {
+					recordProcessingError(errors.Errorf("decode message: %v", err))
 					continue
 				}
 
@@ -324,56 +339,64 @@ func (h *mcapHandler) SendRuleItems(
 				if !ok {
 					fileDescriptorSet := &descriptorpb.FileDescriptorSet{}
 					if err := proto.Unmarshal(schema.Data, fileDescriptorSet); err != nil {
-						log.Errorf("failed to build file descriptor set: %v", err)
+						recordProcessingError(errors.Errorf("build file descriptor set: %v", err))
 						continue
 					}
 					files, err := protodesc.FileOptions{}.NewFiles(fileDescriptorSet)
 					if err != nil {
-						log.Errorf("failed to create file descriptor: %v", err)
+						recordProcessingError(errors.Errorf("create file descriptor: %v", err))
 						continue
 					}
 					descriptor, err := files.FindDescriptorByName(protoreflect.FullName(schema.Name))
 					if err != nil {
-						log.Errorf("failed to find descriptor: %v", err)
+						recordProcessingError(errors.Errorf("find descriptor: %v", err))
 						continue
 					}
-					messageDescriptor, _ = descriptor.(protoreflect.MessageDescriptor)
+					var descriptorOk bool
+					messageDescriptor, descriptorOk = descriptor.(protoreflect.MessageDescriptor)
+					if !descriptorOk {
+						recordProcessingError(errors.Errorf(
+							"descriptor %s is not a message descriptor",
+							schema.Name,
+						))
+						continue
+					}
 					descriptors[channel.SchemaID] = messageDescriptor
 				}
 				protoMsg := dynamicpb.NewMessage(messageDescriptor)
 				if err := proto.Unmarshal(message.Data, protoMsg); err != nil {
-					log.Errorf("failed to parse protobuf message: %v", err)
+					recordProcessingError(errors.Errorf("parse protobuf message: %v", err))
 					continue
 				}
 				marshalledBytes, err := protojson.Marshal(protoMsg)
 				if err != nil {
-					log.Errorf("failed to marshal protobuf to JSON: %v", err)
+					recordProcessingError(errors.Errorf("marshal protobuf to JSON: %v", err))
 					continue
 				}
 				if err := json.Unmarshal(marshalledBytes, &decoded); err != nil {
-					log.Errorf("failed to unmarshal protobuf JSON: %v", err)
+					recordProcessingError(errors.Errorf("unmarshal protobuf JSON: %v", err))
 					continue
 				}
 
 			case "jsonschema":
 				if err := json.Unmarshal(message.Data, &decoded); err != nil {
-					log.Errorf("failed to unmarshal JSON: %v", err)
+					recordProcessingError(errors.Errorf("unmarshal JSON schema message: %v", err))
 					continue
 				}
 
 			default:
-				log.Errorf("unsupported schema encoding: %s", schema.Encoding)
+				recordProcessingError(errors.Errorf("unsupported schema encoding: %s", schema.Encoding))
 				continue
 			}
 		}
 
-		if !sendRuleItem(ctx, ruleItemChan, rule_engine.RuleItem{
+		if err := sendRuleItem(ctx, ruleItemChan, rule_engine.RuleItem{
 			Msg:    decoded,
 			Ts:     utils.FloatSecFromTime(utils.TimeFromFloat(float64(msg.PublishTime))),
 			Topic:  channel.Topic,
 			Source: filepath,
-		}) {
-			return
+		}); err != nil {
+			return err
 		}
 	}
 }

--- a/internal/mod/rule/file_handlers/mcap.go
+++ b/internal/mod/rule/file_handlers/mcap.go
@@ -16,6 +16,7 @@ package file_handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -166,7 +167,12 @@ func getStartTimeEndTimeForUncompletedMcap(filePath string) (*time.Time, *time.T
 	return &start, &end, nil
 }
 
-func (h *mcapHandler) SendRuleItems(filepath string, activeTopics mapset.Set[string], ruleItemChan chan rule_engine.RuleItem) {
+func (h *mcapHandler) SendRuleItems(
+	ctx context.Context,
+	filepath string,
+	activeTopics mapset.Set[string],
+	ruleItemChan chan<- rule_engine.RuleItem,
+) {
 	file, err := os.Open(filepath)
 	if err != nil {
 		log.Errorf("failed to open MCAP file [%s]: %v", filepath, err)
@@ -219,6 +225,10 @@ func (h *mcapHandler) SendRuleItems(filepath string, activeTopics mapset.Set[str
 	errTopics := map[string]struct{}{}
 
 	for {
+		if ctx.Err() != nil {
+			return
+		}
+
 		schema, channel, message, err := iter.NextInto(msg)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
@@ -357,11 +367,13 @@ func (h *mcapHandler) SendRuleItems(filepath string, activeTopics mapset.Set[str
 			}
 		}
 
-		ruleItemChan <- rule_engine.RuleItem{
+		if !sendRuleItem(ctx, ruleItemChan, rule_engine.RuleItem{
 			Msg:    decoded,
 			Ts:     utils.FloatSecFromTime(utils.TimeFromFloat(float64(msg.PublishTime))),
 			Topic:  channel.Topic,
 			Source: filepath,
+		}) {
+			return
 		}
 	}
 }

--- a/internal/mod/rule/file_handlers/ros1.go
+++ b/internal/mod/rule/file_handlers/ros1.go
@@ -16,6 +16,7 @@ package file_handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"strings"
@@ -82,7 +83,12 @@ func (h *ros1Handler) GetStartTimeEndTime(filePath string) (*time.Time, *time.Ti
 	return &start, &end, nil
 }
 
-func (h *ros1Handler) SendRuleItems(filePath string, activeTopics mapset.Set[string], ruleItemChan chan rule_engine.RuleItem) {
+func (h *ros1Handler) SendRuleItems(
+	ctx context.Context,
+	filePath string,
+	activeTopics mapset.Set[string],
+	ruleItemChan chan<- rule_engine.RuleItem,
+) {
 	reader, err := os.Open(filePath)
 	if err != nil {
 		log.Errorf("failed to open ros1 file [%s]: %v", filePath, err)
@@ -135,6 +141,10 @@ func (h *ros1Handler) SendRuleItems(filePath string, activeTopics mapset.Set[str
 
 	// Read messages
 	for it.More() {
+		if ctx.Err() != nil {
+			return
+		}
+
 		conn, msg, err := it.Next()
 		if err != nil {
 			log.Errorf("failed to read message: %v", err)
@@ -182,11 +192,13 @@ func (h *ros1Handler) SendRuleItems(filePath string, activeTopics mapset.Set[str
 
 		sec, nsec := utils.NormalizeFloatTimestamp(float64(msg.Time))
 		// Send JSON message through channel
-		ruleItemChan <- rule_engine.RuleItem{
+		if !sendRuleItem(ctx, ruleItemChan, rule_engine.RuleItem{
 			Msg:    structuredData,
 			Ts:     float64(sec) + float64(nsec)/1e9,
 			Topic:  conn.Topic,
 			Source: filePath,
+		}) {
+			return
 		}
 	}
 	log.Infof("finished sending rule items for ros1 file %s", filePath)

--- a/internal/mod/rule/file_handlers/ros1.go
+++ b/internal/mod/rule/file_handlers/ros1.go
@@ -88,24 +88,25 @@ func (h *ros1Handler) SendRuleItems(
 	filePath string,
 	activeTopics mapset.Set[string],
 	ruleItemChan chan<- rule_engine.RuleItem,
-) {
+) error {
 	reader, err := os.Open(filePath)
 	if err != nil {
 		log.Errorf("failed to open ros1 file [%s]: %v", filePath, err)
-		return
+		return errors.Errorf("open ros1 file [%s]: %v", filePath, err)
 	}
+	defer reader.Close()
 
 	// Create bag reader
 	bagReader, err := rosbag.NewReader(reader)
 	if err != nil {
 		log.Errorf("failed to create bag reader: %v", err)
-		return
+		return errors.Errorf("create ros1 bag reader: %v", err)
 	}
 
 	info, err := bagReader.Info()
 	if err != nil {
 		log.Errorf("failed to get info for ros1 file %s: %v", filePath, err)
-		return
+		return errors.Errorf("get info for ros1 file %s: %v", filePath, err)
 	}
 
 	// targetTopics will be empty if there is no active topic
@@ -121,7 +122,7 @@ func (h *ros1Handler) SendRuleItems(
 
 		if targetTopics.Cardinality() == 0 {
 			log.Infof("no active topics matched in ros1 file %s, skipping", filePath)
-			return
+			return nil
 		}
 	}
 	log.Infof("sending rule items for ros1 file %s with topics: %v", filePath, targetTopics)
@@ -130,7 +131,7 @@ func (h *ros1Handler) SendRuleItems(
 	it, err := bagReader.Messages()
 	if err != nil {
 		log.Errorf("failed to create message iterator: %v", err)
-		return
+		return errors.Errorf("create ros1 message iterator: %v", err)
 	}
 
 	// Map to store JSON transcoders for each connection
@@ -138,17 +139,24 @@ func (h *ros1Handler) SendRuleItems(
 
 	// Set to store conn failed to transcode
 	failedConnToTranscode := mapset.NewSet[uint32]()
+	var processingErr error
+	recordProcessingError := func(err error) {
+		log.Error(err)
+		if processingErr == nil {
+			processingErr = err
+		}
+	}
 
 	// Read messages
 	for it.More() {
 		if ctx.Err() != nil {
-			return
+			return ctx.Err()
 		}
 
 		conn, msg, err := it.Next()
 		if err != nil {
 			log.Errorf("failed to read message: %v", err)
-			continue
+			return errors.Errorf("read ros1 message: %v", err)
 		}
 		if targetTopics.Cardinality() > 0 && !targetTopics.Contains(conn.Topic) {
 			continue
@@ -168,7 +176,7 @@ func (h *ros1Handler) SendRuleItems(
 			}
 			transcoder, err = ros1msg.NewJSONTranscoder(parentPackage, conn.Data.MessageDefinition)
 			if err != nil {
-				log.Errorf("failed to create JSON transcoder: %v", err)
+				recordProcessingError(errors.Errorf("create JSON transcoder: %v", err))
 				failedConnToTranscode.Add(conn.Conn)
 				continue
 			}
@@ -179,27 +187,28 @@ func (h *ros1Handler) SendRuleItems(
 		var buf bytes.Buffer
 		err = transcoder.Transcode(&buf, bytes.NewReader(msg.Data))
 		if err != nil {
-			log.Errorf("failed to transcode message: %v", err)
+			recordProcessingError(errors.Errorf("transcode ros1 message: %v", err))
 			continue
 		}
 
 		// Parse JSON into structured data
 		var structuredData map[string]interface{}
 		if err := json.Unmarshal(buf.Bytes(), &structuredData); err != nil {
-			log.Errorf("failed to parse JSON: %v", err)
+			recordProcessingError(errors.Errorf("parse ros1 message JSON: %v", err))
 			continue
 		}
 
 		sec, nsec := utils.NormalizeFloatTimestamp(float64(msg.Time))
 		// Send JSON message through channel
-		if !sendRuleItem(ctx, ruleItemChan, rule_engine.RuleItem{
+		if err := sendRuleItem(ctx, ruleItemChan, rule_engine.RuleItem{
 			Msg:    structuredData,
 			Ts:     float64(sec) + float64(nsec)/1e9,
 			Topic:  conn.Topic,
 			Source: filePath,
-		}) {
-			return
+		}); err != nil {
+			return err
 		}
 	}
 	log.Infof("finished sending rule items for ros1 file %s", filePath)
+	return processingErr
 }

--- a/internal/mod/rule/file_handlers/ros1.go
+++ b/internal/mod/rule/file_handlers/ros1.go
@@ -139,12 +139,8 @@ func (h *ros1Handler) SendRuleItems(
 
 	// Set to store conn failed to transcode
 	failedConnToTranscode := mapset.NewSet[uint32]()
-	var processingErr error
-	recordProcessingError := func(err error) {
+	logMessageError := func(err error) {
 		log.Error(err)
-		if processingErr == nil {
-			processingErr = err
-		}
 	}
 
 	// Read messages
@@ -176,7 +172,7 @@ func (h *ros1Handler) SendRuleItems(
 			}
 			transcoder, err = ros1msg.NewJSONTranscoder(parentPackage, conn.Data.MessageDefinition)
 			if err != nil {
-				recordProcessingError(errors.Errorf("create JSON transcoder: %v", err))
+				logMessageError(errors.Errorf("create JSON transcoder: %v", err))
 				failedConnToTranscode.Add(conn.Conn)
 				continue
 			}
@@ -187,14 +183,14 @@ func (h *ros1Handler) SendRuleItems(
 		var buf bytes.Buffer
 		err = transcoder.Transcode(&buf, bytes.NewReader(msg.Data))
 		if err != nil {
-			recordProcessingError(errors.Errorf("transcode ros1 message: %v", err))
+			logMessageError(errors.Errorf("transcode ros1 message: %v", err))
 			continue
 		}
 
 		// Parse JSON into structured data
 		var structuredData map[string]interface{}
 		if err := json.Unmarshal(buf.Bytes(), &structuredData); err != nil {
-			recordProcessingError(errors.Errorf("parse ros1 message JSON: %v", err))
+			logMessageError(errors.Errorf("parse ros1 message JSON: %v", err))
 			continue
 		}
 
@@ -210,5 +206,5 @@ func (h *ros1Handler) SendRuleItems(
 		}
 	}
 	log.Infof("finished sending rule items for ros1 file %s", filePath)
-	return processingErr
+	return nil
 }

--- a/internal/mod/rule/file_state_handler/file_state_handler.go
+++ b/internal/mod/rule/file_state_handler/file_state_handler.go
@@ -53,6 +53,10 @@ type FileStateHandler interface {
 	// to mark them as processed.
 	MarkProcessedFile(filename string) error
 
+	// MarkFailedFile marks a file as permanently failed. Failed files remain
+	// terminal until their size or modification time changes.
+	MarkFailedFile(filename string) error
+
 	// GetFileHandler returns the handler for a given file path.
 	GetFileHandler(filePath string) file_handlers.Interface
 }
@@ -65,6 +69,7 @@ const (
 	processStateSeenOnce
 	processStateReadyToProcess
 	processStateProcessed
+	processStateFailed
 )
 
 // FileState represents the state of a file in the system.
@@ -277,15 +282,34 @@ func (f *fileStateHandler) saveState() error {
 
 // setFileState updates the state for a given file path.
 func (f *fileStateHandler) setFileState(filePath string, state FileState) {
+	if err := f.updateFileState(filePath, func(FileState, bool) (FileState, bool) {
+		return state, true
+	}); err != nil {
+		log.Errorf("Failed to update file state for %s: %v", filePath, err)
+	}
+}
+
+// updateFileState applies a read-modify-write operation while holding stateLock.
+// The callback must only update in-memory state and must not perform file I/O.
+func (f *fileStateHandler) updateFileState(
+	filePath string,
+	update func(current FileState, exists bool) (next FileState, keep bool),
+) error {
 	absPath, err := filepath.Abs(filePath)
 	if err != nil {
-		log.Errorf("Failed to get absolute path for %s: %v", filePath, err)
-		return
+		return errors.Errorf("failed to get absolute path for %s: %v", filePath, err)
 	}
 
 	f.stateLock.Lock()
 	defer f.stateLock.Unlock()
-	f.state[absPath] = state
+	current, exists := f.state[absPath]
+	next, keep := update(current, exists)
+	if !keep {
+		delete(f.state, absPath)
+		return nil
+	}
+	f.state[absPath] = next
+	return nil
 }
 
 // delFileState removes the state for a given file path.
@@ -330,11 +354,24 @@ func (f *fileStateHandler) checkpointFileState(checkpoints map[string]fileStateC
 
 func (f *fileStateHandler) restoreFileStates(checkpoints map[string]fileStateCheckpoint) {
 	for filePath, checkpoint := range checkpoints {
-		if checkpoint.exists {
-			f.setFileState(filePath, checkpoint.state)
-			continue
-		}
-		if err := f.delFileState(filePath); err != nil {
+		err := f.updateFileState(filePath, func(current FileState, exists bool) (FileState, bool) {
+			if checkpoint.exists {
+				restored := checkpoint.state
+				if exists && current.ProcessState != checkpoint.state.ProcessState {
+					restored.ProcessState = current.ProcessState
+				}
+				return restored, true
+			}
+
+			// A non-default process state can only have been written after the
+			// checkpoint. Preserve that concurrent transition instead of
+			// deleting the newly-created state.
+			if exists && current.ProcessState != processStateUnprocessed {
+				return current, true
+			}
+			return FileState{}, false
+		})
+		if err != nil {
 			log.Errorf("Failed to roll back file state for %s: %v", filePath, err)
 		}
 	}
@@ -619,6 +656,39 @@ func (f *fileStateHandler) UpdateCollectDirs(whitelist []string, conf config.Def
 	return nil
 }
 
+func fileContentsChanged(state FileState, info os.FileInfo) bool {
+	return state.Size != info.Size() || state.ModifyTime != info.ModTime().UnixNano()
+}
+
+func nextScannedProcessState(state FileState, exists bool, info os.FileInfo) processState {
+	if exists && state.ProcessState == processStateFailed && fileContentsChanged(state, info) {
+		return processStateUnprocessed
+	}
+	if exists {
+		return state.ProcessState
+	}
+	return processStateUnprocessed
+}
+
+// applyScannedFileState merges a scan result with the latest in-memory state.
+// If processing advanced while the scanner was doing file I/O, the latest
+// process state wins over the scanner's stale observation.
+func (f *fileStateHandler) applyScannedFileState(
+	filePath string,
+	observed FileState,
+	observedExists bool,
+	scanned FileState,
+) {
+	if err := f.updateFileState(filePath, func(current FileState, exists bool) (FileState, bool) {
+		if exists && (!observedExists || current.ProcessState != observed.ProcessState) {
+			scanned.ProcessState = current.ProcessState
+		}
+		return scanned, true
+	}); err != nil {
+		log.Errorf("Failed to apply scanned file state for %s: %v", filePath, err)
+	}
+}
+
 func (f *fileStateHandler) processListenFile(absPath string, info os.FileInfo, skipPeriodHours int) {
 	fileState, hasFileState := f.getFileState(absPath)
 
@@ -626,26 +696,34 @@ func (f *fileStateHandler) processListenFile(absPath string, info os.FileInfo, s
 	if hasFileState && !fileState.Unsupported && fileState.ProcessState == processStateProcessed {
 		return
 	}
+	// A permanently failed file is retried only after its contents change.
+	if hasFileState && fileState.ProcessState == processStateFailed && !fileContentsChanged(fileState, info) {
+		return
+	}
 
 	handler := f.GetFileHandler(absPath)
 	if handler == nil {
 		// No handler supported for file, mark as unsupported if not already
 		if !hasFileState || !fileState.Unsupported {
-			f.setFileState(absPath, FileState{
-				Size:        info.Size(),
-				Unsupported: true,
-			})
+			newState := fileState
+			newState.Size = info.Size()
+			newState.ModifyTime = info.ModTime().UnixNano()
+			newState.Unsupported = true
+			newState.ProcessState = nextScannedProcessState(fileState, hasFileState, info)
+			f.applyScannedFileState(absPath, fileState, hasFileState, newState)
 		}
 		return
 	}
 
 	// Check if file is too old
 	if !info.IsDir() && info.ModTime().Before(time.Now().Add(-time.Duration(skipPeriodHours)*time.Hour)) {
-		f.setFileState(absPath, FileState{
-			Size:        info.Size(),
-			Unsupported: true,
-			TooOld:      true,
-		})
+		newState := fileState
+		newState.Size = info.Size()
+		newState.ModifyTime = info.ModTime().UnixNano()
+		newState.Unsupported = true
+		newState.TooOld = true
+		newState.ProcessState = nextScannedProcessState(fileState, hasFileState, info)
+		f.applyScannedFileState(absPath, fileState, hasFileState, newState)
 		return
 	}
 
@@ -657,11 +735,12 @@ func (f *fileStateHandler) processListenFile(absPath string, info os.FileInfo, s
 		}
 
 		newState.Size = info.Size()
-		newState.ModifyTime = info.ModTime().Unix()
+		newState.ModifyTime = info.ModTime().UnixNano()
 		newState.IsListening = true
 		newState.Unsupported = false
 		newState.TooOld = false
-		f.setFileState(absPath, newState)
+		newState.ProcessState = nextScannedProcessState(fileState, hasFileState, info)
+		f.applyScannedFileState(absPath, fileState, hasFileState, newState)
 		return
 	} else {
 		log.Infof("Listening file %s is not finished, will be processed later", absPath)
@@ -671,27 +750,28 @@ func (f *fileStateHandler) processListenFile(absPath string, info os.FileInfo, s
 func (f *fileStateHandler) processCollectFile(absPath string, info os.FileInfo) {
 	fileState, hasFileState := f.getFileState(absPath)
 
-	// Skip file if file is not modified
+	// Skip terminal files while their contents are unchanged.
 	if hasFileState &&
 		!fileState.Unsupported &&
-		fileState.ProcessState == processStateProcessed &&
-		fileState.ModifyTime == info.ModTime().Unix() {
+		(fileState.ProcessState == processStateProcessed || fileState.ProcessState == processStateFailed) &&
+		!fileContentsChanged(fileState, info) {
 		return
 	}
 
 	handler := f.GetFileHandler(absPath)
 	if handler == nil {
-		f.setFileState(absPath, FileState{
-			Size:        info.Size(),
-			ModifyTime:  info.ModTime().Unix(),
-			Unsupported: true,
-		})
+		newState := fileState
+		newState.Size = info.Size()
+		newState.ModifyTime = info.ModTime().UnixNano()
+		newState.Unsupported = true
+		newState.ProcessState = nextScannedProcessState(fileState, hasFileState, info)
+		f.applyScannedFileState(absPath, fileState, hasFileState, newState)
 		return
 	}
 
 	// Update state
 	newState := fileState
-	if !hasFileState || fileState.ModifyTime != info.ModTime().Unix() {
+	if !hasFileState || fileContentsChanged(fileState, info) {
 		var startTime, endTime *time.Time
 
 		// Try to use file creation time and modification time if available
@@ -710,11 +790,12 @@ func (f *fileStateHandler) processCollectFile(absPath string, info os.FileInfo) 
 			if err != nil {
 				log.Errorf("Error getting start and end time for %s: %v, skip collect", absPath, err)
 
-				f.setFileState(absPath, FileState{
-					Size:        info.Size(),
-					ModifyTime:  info.ModTime().Unix(),
-					Unsupported: true,
-				})
+				newState := fileState
+				newState.Size = info.Size()
+				newState.ModifyTime = info.ModTime().UnixNano()
+				newState.Unsupported = true
+				newState.ProcessState = nextScannedProcessState(fileState, hasFileState, info)
+				f.applyScannedFileState(absPath, fileState, hasFileState, newState)
 				return
 			}
 		}
@@ -723,7 +804,7 @@ func (f *fileStateHandler) processCollectFile(absPath string, info os.FileInfo) 
 			Size:       info.Size(),
 			StartTime:  startTime.Unix(),
 			EndTime:    endTime.Unix(),
-			ModifyTime: info.ModTime().Unix(),
+			ModifyTime: info.ModTime().UnixNano(),
 		}
 
 		log.Infof("Collecting file %s start time: %s, end time: %s", absPath, startTime.UTC().String(), endTime.UTC().String())
@@ -731,26 +812,31 @@ func (f *fileStateHandler) processCollectFile(absPath string, info os.FileInfo) 
 
 	newState.IsCollecting = true
 	newState.ProcessState = processStateProcessed
+	if fileState.ProcessState == processStateFailed && fileContentsChanged(fileState, info) {
+		newState.ProcessState = processStateUnprocessed
+	}
 
-	f.setFileState(absPath, newState)
+	f.applyScannedFileState(absPath, fileState, hasFileState, newState)
 }
 
 func (f *fileStateHandler) UpdateFilesProcessState() error {
-	for filename, state := range f.stateSnapshot() {
-		if !state.IsListening {
-			continue
-		}
+	for _, filename := range f.stateKeysSnapshot() {
+		if err := f.updateFileState(filename, func(state FileState, exists bool) (FileState, bool) {
+			if !exists || !state.IsListening {
+				return state, exists
+			}
 
-		switch state.ProcessState {
-		case processStateUnprocessed:
-			state.ProcessState = processStateSeenOnce
-		case processStateSeenOnce:
-			state.ProcessState = processStateReadyToProcess
-		case processStateReadyToProcess, processStateProcessed:
-			continue
+			switch state.ProcessState {
+			case processStateUnprocessed:
+				state.ProcessState = processStateSeenOnce
+			case processStateSeenOnce:
+				state.ProcessState = processStateReadyToProcess
+			case processStateReadyToProcess, processStateProcessed, processStateFailed:
+			}
+			return state, true
+		}); err != nil {
+			return errors.Errorf("failed to update process state for %s: %v", filename, err)
 		}
-
-		f.setFileState(filename, state)
 	}
 	if err := f.saveState(); err != nil {
 		return errors.Errorf("failed to save state: %v", err)
@@ -760,14 +846,28 @@ func (f *fileStateHandler) UpdateFilesProcessState() error {
 }
 
 func (f *fileStateHandler) MarkProcessedFile(filename string) error {
-	state, exists := f.getFileState(filename)
+	return f.markFileProcessState(filename, processStateProcessed)
+}
+
+func (f *fileStateHandler) MarkFailedFile(filename string) error {
+	return f.markFileProcessState(filename, processStateFailed)
+}
+
+func (f *fileStateHandler) markFileProcessState(filename string, nextProcessState processState) error {
+	exists := false
+	if err := f.updateFileState(filename, func(state FileState, currentExists bool) (FileState, bool) {
+		if !currentExists {
+			return state, false
+		}
+		exists = true
+		state.ProcessState = nextProcessState
+		return state, true
+	}); err != nil {
+		return err
+	}
 	if !exists {
 		return errors.Errorf("file state for %s does not exist", filename)
 	}
-
-	state.ProcessState = processStateProcessed
-
-	f.setFileState(filename, state)
 
 	if err := f.saveState(); err != nil {
 		return errors.Errorf("failed to save state: %v", err)

--- a/internal/mod/rule/file_state_handler/file_state_handler.go
+++ b/internal/mod/rule/file_state_handler/file_state_handler.go
@@ -31,7 +31,6 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/djherbis/times"
 	"github.com/pkg/errors"
-	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -94,7 +93,8 @@ type SavedState struct {
 // fileStateHandler is used to keep track of the state of files in directories.
 type fileStateHandler struct {
 	state        map[string]FileState
-	updateLock   sync.Mutex
+	stateLock    sync.RWMutex
+	saveLock     sync.Mutex
 	listenDirs   mapset.Set[string]
 	collectDirs  mapset.Set[string]
 	activeTopics mapset.Set[string]
@@ -187,27 +187,77 @@ func (f *fileStateHandler) loadState() error {
 		log.Warnf("Invalid file state file: %v, reset to init", err)
 	}
 
-	f.state = savedState.State
-	f.listenDirs = mapset.NewSet[string]()
-	f.collectDirs = mapset.NewSet[string]()
+	if savedState.State == nil {
+		savedState.State = make(map[string]FileState)
+	}
+	listenDirs := mapset.NewSet(savedState.ListenDirs...)
+	collectDirs := mapset.NewSet(savedState.CollectDirs...)
 
-	for _, dir := range savedState.ListenDirs {
-		f.listenDirs.Add(dir)
-	}
-	for _, dir := range savedState.CollectDirs {
-		f.collectDirs.Add(dir)
-	}
+	f.stateLock.Lock()
+	f.state = savedState.State
+	f.listenDirs = listenDirs
+	f.collectDirs = collectDirs
+	f.stateLock.Unlock()
 
 	return nil
 }
 
-// SaveState saves the current state to disk.
-func (f *fileStateHandler) saveState() error {
-	savedState := SavedState{
-		State:       f.state,
+func (f *fileStateHandler) savedStateSnapshot() SavedState {
+	f.stateLock.RLock()
+	defer f.stateLock.RUnlock()
+
+	state := make(map[string]FileState, len(f.state))
+	for filename, fileState := range f.state {
+		state[filename] = fileState
+	}
+
+	return SavedState{
+		State:       state,
 		ListenDirs:  f.listenDirs.ToSlice(),
 		CollectDirs: f.collectDirs.ToSlice(),
 	}
+}
+
+func (f *fileStateHandler) stateKeysSnapshot() []string {
+	f.stateLock.RLock()
+	defer f.stateLock.RUnlock()
+
+	filenames := make([]string, 0, len(f.state))
+	for filename := range f.state {
+		filenames = append(filenames, filename)
+	}
+	return filenames
+}
+
+func (f *fileStateHandler) stateSnapshot() map[string]FileState {
+	f.stateLock.RLock()
+	defer f.stateLock.RUnlock()
+
+	state := make(map[string]FileState, len(f.state))
+	for filename, fileState := range f.state {
+		state[filename] = fileState
+	}
+	return state
+}
+
+func (f *fileStateHandler) listenDirsSnapshot() mapset.Set[string] {
+	f.stateLock.RLock()
+	defer f.stateLock.RUnlock()
+	return mapset.NewSet(f.listenDirs.ToSlice()...)
+}
+
+func (f *fileStateHandler) collectDirsSnapshot() mapset.Set[string] {
+	f.stateLock.RLock()
+	defer f.stateLock.RUnlock()
+	return mapset.NewSet(f.collectDirs.ToSlice()...)
+}
+
+// SaveState saves the current state to disk.
+func (f *fileStateHandler) saveState() error {
+	f.saveLock.Lock()
+	defer f.saveLock.Unlock()
+
+	savedState := f.savedStateSnapshot()
 
 	data, err := json.MarshalIndent(savedState, "", "  ")
 	if err != nil {
@@ -233,8 +283,8 @@ func (f *fileStateHandler) setFileState(filePath string, state FileState) {
 		return
 	}
 
-	f.updateLock.Lock()
-	defer f.updateLock.Unlock()
+	f.stateLock.Lock()
+	defer f.stateLock.Unlock()
 	f.state[absPath] = state
 }
 
@@ -245,8 +295,8 @@ func (f *fileStateHandler) delFileState(filePath string) error {
 		return errors.Errorf("failed to get absolute path for %s: %v", filePath, err)
 	}
 
-	f.updateLock.Lock()
-	defer f.updateLock.Unlock()
+	f.stateLock.Lock()
+	defer f.stateLock.Unlock()
 	delete(f.state, absPath)
 	return nil
 }
@@ -259,6 +309,8 @@ func (f *fileStateHandler) getFileState(filePath string) (FileState, bool) {
 		return FileState{}, false
 	}
 
+	f.stateLock.RLock()
+	defer f.stateLock.RUnlock()
 	state, exists := f.state[absPath]
 	return state, exists
 }
@@ -290,7 +342,7 @@ func (f *fileStateHandler) restoreFileStates(checkpoints map[string]fileStateChe
 
 // updateDeletedFileState removes state entries for files that no longer exist.
 func (f *fileStateHandler) updateDeletedFileState() error {
-	for _, filename := range lo.Keys(f.state) {
+	for _, filename := range f.stateKeysSnapshot() {
 		if _, err := os.Stat(filename); os.IsNotExist(err) {
 			if err = f.delFileState(filename); err != nil {
 				return errors.Errorf("failed to delete file state for %s: %v", filename, err)
@@ -313,10 +365,10 @@ func (f *fileStateHandler) UpdateListenDirs(conf config.DefaultModConfConfig) er
 	log.Infof("Start updating directories, listen_dirs: %v", newListenDirs)
 
 	// Find directories that are no longer being monitored
-	deleteDirs := f.listenDirs.Difference(newListenDirs)
+	deleteDirs := f.listenDirsSnapshot().Difference(newListenDirs)
 
 	// Delete state of files in directories that are no longer scanned
-	for filename := range f.state {
+	for _, filename := range f.stateKeysSnapshot() {
 		for dir := range deleteDirs.Iter() {
 			if strings.HasPrefix(filename, dir) {
 				if err := f.delFileState(filename); err != nil {
@@ -400,7 +452,9 @@ func (f *fileStateHandler) UpdateListenDirs(conf config.DefaultModConfConfig) er
 	}
 
 	// Update directory sets
+	f.stateLock.Lock()
 	f.listenDirs = newListenDirs
+	f.stateLock.Unlock()
 
 	// Clean up deleted files
 	if err := f.updateDeletedFileState(); err != nil {
@@ -427,10 +481,10 @@ func (f *fileStateHandler) UpdateCollectDirs(whitelist []string, conf config.Def
 	log.Infof("Start updating directories, collector_dirs: %v", newCollectDirs)
 
 	// Find directories that are no longer being monitored
-	deleteDirs := f.collectDirs.Difference(newCollectDirs)
+	deleteDirs := f.collectDirsSnapshot().Difference(newCollectDirs)
 
 	// Delete state of files in directories that are no longer collected
-	for filename := range f.state {
+	for _, filename := range f.stateKeysSnapshot() {
 		for dir := range deleteDirs.Iter() {
 			if strings.HasPrefix(filename, dir) {
 				if err := f.delFileState(filename); err != nil {
@@ -547,7 +601,9 @@ func (f *fileStateHandler) UpdateCollectDirs(whitelist []string, conf config.Def
 	}
 
 	// Update directory sets
+	f.stateLock.Lock()
 	f.collectDirs = newCollectDirs
+	f.stateLock.Unlock()
 
 	// Clean up deleted files
 	if err := f.updateDeletedFileState(); err != nil {
@@ -680,7 +736,7 @@ func (f *fileStateHandler) processCollectFile(absPath string, info os.FileInfo) 
 }
 
 func (f *fileStateHandler) UpdateFilesProcessState() error {
-	for filename, state := range f.state {
+	for filename, state := range f.stateSnapshot() {
 		if !state.IsListening {
 			continue
 		}
@@ -725,11 +781,8 @@ type FileFilter func(string, FileState) bool
 
 // Files returns files matching the given filters.
 func (f *fileStateHandler) Files(filters ...FileFilter) []FileState {
-	f.updateLock.Lock()
-	defer f.updateLock.Unlock()
-
 	var result []FileState
-	for filename, state := range f.state {
+	for filename, state := range f.stateSnapshot() {
 		if state.Unsupported {
 			continue
 		}

--- a/internal/mod/rule/file_state_handler/file_state_handler_test.go
+++ b/internal/mod/rule/file_state_handler/file_state_handler_test.go
@@ -98,6 +98,8 @@ func TestRecursiveDirectoryUpdatesRollBackAfterLaterTraversalError(t *testing.T)
 }
 
 func TestConcurrentStateAccessAndPersistence(t *testing.T) {
+	t.Parallel()
+
 	handler := newTestFileStateHandler(t)
 	baseDir := t.TempDir()
 	const iterations = 500
@@ -108,20 +110,20 @@ func TestConcurrentStateAccessAndPersistence(t *testing.T) {
 	wg.Add(4)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+		for i := range iterations {
 			filename := filepath.Join(baseDir, fmt.Sprintf("%d.log", i))
 			handler.setFileState(filename, FileState{Size: int64(i), IsListening: true})
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			_ = handler.Files()
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			if err := handler.saveState(); err != nil {
 				errs <- err
 			}
@@ -129,7 +131,7 @@ func TestConcurrentStateAccessAndPersistence(t *testing.T) {
 	}()
 	go func() {
 		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+		for i := range iterations {
 			_, _ = handler.getFileState(filepath.Join(baseDir, fmt.Sprintf("%d.log", i)))
 		}
 	}()
@@ -142,6 +144,8 @@ func TestConcurrentStateAccessAndPersistence(t *testing.T) {
 }
 
 func TestConcurrentDirectoryUpdates(t *testing.T) {
+	t.Parallel()
+
 	handler := newTestFileStateHandler(t)
 	listenDir := t.TempDir()
 	collectDir := t.TempDir()
@@ -153,7 +157,7 @@ func TestConcurrentDirectoryUpdates(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			if err := handler.UpdateListenDirs(config.DefaultModConfConfig{
 				ListenDirs: []string{listenDir},
 			}); err != nil {
@@ -163,7 +167,7 @@ func TestConcurrentDirectoryUpdates(t *testing.T) {
 	}()
 	go func() {
 		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			if err := handler.UpdateCollectDirs(nil, config.DefaultModConfConfig{
 				CollectDirs: []string{collectDir},
 			}); err != nil {

--- a/internal/mod/rule/file_state_handler/file_state_handler_test.go
+++ b/internal/mod/rule/file_state_handler/file_state_handler_test.go
@@ -234,6 +234,8 @@ func TestConcurrentDirectoryUpdates(t *testing.T) {
 }
 
 func TestProcessListenFileDoesNotRevertConcurrentProcessedState(t *testing.T) {
+	t.Parallel()
+
 	handler := newTestFileStateHandler(t)
 	filePath := filepath.Join(t.TempDir(), "active.log")
 	require.NoError(t, os.WriteFile(filePath, []byte("log"), 0o600))
@@ -269,6 +271,8 @@ func TestProcessListenFileDoesNotRevertConcurrentProcessedState(t *testing.T) {
 }
 
 func TestFailedFileIsNotReadyUntilItsContentsChange(t *testing.T) {
+	t.Parallel()
+
 	handler := newTestFileStateHandler(t)
 	filePath := filepath.Join(t.TempDir(), "failed.log")
 	require.NoError(t, os.WriteFile(filePath, []byte("old"), 0o600))
@@ -300,6 +304,8 @@ func TestFailedFileIsNotReadyUntilItsContentsChange(t *testing.T) {
 }
 
 func TestFailedFileRetriesWhenOnlyModTimeNanosecondsChange(t *testing.T) {
+	t.Parallel()
+
 	handler := newTestFileStateHandler(t)
 	filePath := filepath.Join(t.TempDir(), "same-size.log")
 	require.NoError(t, os.WriteFile(filePath, []byte("same"), 0o600))
@@ -328,6 +334,8 @@ func TestFailedFileRetriesWhenOnlyModTimeNanosecondsChange(t *testing.T) {
 }
 
 func TestRestoreFileStatesPreservesConcurrentProcessState(t *testing.T) {
+	t.Parallel()
+
 	handler := newTestFileStateHandler(t)
 	filePath := filepath.Join(t.TempDir(), "restore.log")
 	original := FileState{

--- a/internal/mod/rule/file_state_handler/file_state_handler_test.go
+++ b/internal/mod/rule/file_state_handler/file_state_handler_test.go
@@ -15,14 +15,29 @@
 package file_state_handler
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/coscene-io/coscout/internal/config"
 	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/stretchr/testify/require"
 )
+
+func newTestFileStateHandler(t *testing.T) *fileStateHandler {
+	t.Helper()
+
+	return &fileStateHandler{
+		state:        make(map[string]FileState),
+		listenDirs:   mapset.NewSet[string](),
+		collectDirs:  mapset.NewSet[string](),
+		activeTopics: mapset.NewSet[string](),
+		statePath:    filepath.Join(t.TempDir(), "file-state.json"),
+	}
+}
 
 func TestRecursiveDirectoryUpdatesRollBackAfterLaterTraversalError(t *testing.T) {
 	t.Parallel()
@@ -79,5 +94,87 @@ func TestRecursiveDirectoryUpdatesRollBackAfterLaterTraversalError(t *testing.T)
 				t.Fatalf("state = %#v, want original state restored after later traversal error", handler.state)
 			}
 		})
+	}
+}
+
+func TestConcurrentStateAccessAndPersistence(t *testing.T) {
+	handler := newTestFileStateHandler(t)
+	baseDir := t.TempDir()
+	const iterations = 500
+
+	var wg sync.WaitGroup
+	errs := make(chan error, iterations)
+
+	wg.Add(4)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			filename := filepath.Join(baseDir, fmt.Sprintf("%d.log", i))
+			handler.setFileState(filename, FileState{Size: int64(i), IsListening: true})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = handler.Files()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if err := handler.saveState(); err != nil {
+				errs <- err
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _ = handler.getFileState(filepath.Join(baseDir, fmt.Sprintf("%d.log", i)))
+		}
+	}()
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func TestConcurrentDirectoryUpdates(t *testing.T) {
+	handler := newTestFileStateHandler(t)
+	listenDir := t.TempDir()
+	collectDir := t.TempDir()
+	const iterations = 25
+
+	var wg sync.WaitGroup
+	errs := make(chan error, iterations*2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if err := handler.UpdateListenDirs(config.DefaultModConfConfig{
+				ListenDirs: []string{listenDir},
+			}); err != nil {
+				errs <- err
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if err := handler.UpdateCollectDirs(nil, config.DefaultModConfConfig{
+				CollectDirs: []string{collectDir},
+			}); err != nil {
+				errs <- err
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
 	}
 }

--- a/internal/mod/rule/file_state_handler/file_state_handler_test.go
+++ b/internal/mod/rule/file_state_handler/file_state_handler_test.go
@@ -15,17 +15,67 @@
 package file_state_handler
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/coscene-io/coscout/internal/config"
+	"github.com/coscene-io/coscout/internal/mod/rule/file_handlers"
+	"github.com/coscene-io/coscout/pkg/rule_engine"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/stretchr/testify/require"
 )
+
+type blockingFinishedHandler struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+type fileInfoWithModTime struct {
+	os.FileInfo
+	modTime time.Time
+}
+
+func (i fileInfoWithModTime) ModTime() time.Time {
+	return i.modTime
+}
+
+func (h *blockingFinishedHandler) CheckFilePath(string) bool {
+	return true
+}
+
+func (h *blockingFinishedHandler) GetStartTimeEndTime(string) (*time.Time, *time.Time, error) {
+	now := time.Now()
+	return &now, &now, nil
+}
+
+func (h *blockingFinishedHandler) GetFileSize(string) (int64, error) {
+	return 0, nil
+}
+
+func (h *blockingFinishedHandler) IsFinished(string) bool {
+	if h.started != nil {
+		close(h.started)
+	}
+	if h.release != nil {
+		<-h.release
+	}
+	return true
+}
+
+func (h *blockingFinishedHandler) SendRuleItems(
+	context.Context,
+	string,
+	mapset.Set[string],
+	chan<- rule_engine.RuleItem,
+) error {
+	return nil
+}
 
 func newTestFileStateHandler(t *testing.T) *fileStateHandler {
 	t.Helper()
@@ -181,4 +231,121 @@ func TestConcurrentDirectoryUpdates(t *testing.T) {
 	for err := range errs {
 		require.NoError(t, err)
 	}
+}
+
+func TestProcessListenFileDoesNotRevertConcurrentProcessedState(t *testing.T) {
+	handler := newTestFileStateHandler(t)
+	filePath := filepath.Join(t.TempDir(), "active.log")
+	require.NoError(t, os.WriteFile(filePath, []byte("log"), 0o600))
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	handler.setFileState(filePath, FileState{
+		Size:         info.Size(),
+		ModifyTime:   info.ModTime().UnixNano(),
+		IsListening:  true,
+		ProcessState: processStateSeenOnce,
+	})
+	blockingHandler := &blockingFinishedHandler{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	handler.handlers = []file_handlers.Interface{blockingHandler}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.processListenFile(filePath, info, 24)
+	}()
+
+	<-blockingHandler.started
+	require.NoError(t, handler.MarkProcessedFile(filePath))
+	close(blockingHandler.release)
+	<-done
+
+	state, exists := handler.getFileState(filePath)
+	require.True(t, exists)
+	require.Equal(t, processStateProcessed, state.ProcessState)
+}
+
+func TestFailedFileIsNotReadyUntilItsContentsChange(t *testing.T) {
+	handler := newTestFileStateHandler(t)
+	filePath := filepath.Join(t.TempDir(), "failed.log")
+	require.NoError(t, os.WriteFile(filePath, []byte("old"), 0o600))
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	handler.setFileState(filePath, FileState{
+		Size:         info.Size(),
+		ModifyTime:   info.ModTime().UnixNano(),
+		IsListening:  true,
+		ProcessState: processStateReadyToProcess,
+	})
+	require.NoError(t, handler.MarkFailedFile(filePath))
+	require.NoError(t, handler.UpdateFilesProcessState())
+	require.NoError(t, handler.UpdateFilesProcessState())
+	require.Empty(t, handler.Files(FilterReadyToProcess()))
+
+	require.NoError(t, os.WriteFile(filePath, []byte("new contents"), 0o600))
+	modifiedInfo, err := os.Stat(filePath)
+	require.NoError(t, err)
+	handler.handlers = []file_handlers.Interface{&blockingFinishedHandler{}}
+
+	handler.processListenFile(filePath, modifiedInfo, 24)
+
+	state, exists := handler.getFileState(filePath)
+	require.True(t, exists)
+	require.Equal(t, processStateUnprocessed, state.ProcessState)
+	require.Equal(t, modifiedInfo.Size(), state.Size)
+}
+
+func TestFailedFileRetriesWhenOnlyModTimeNanosecondsChange(t *testing.T) {
+	handler := newTestFileStateHandler(t)
+	filePath := filepath.Join(t.TempDir(), "same-size.log")
+	require.NoError(t, os.WriteFile(filePath, []byte("same"), 0o600))
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	oldModTime := time.Now().Truncate(time.Second).Add(100 * time.Nanosecond)
+	newModTime := oldModTime.Add(time.Nanosecond)
+	handler.setFileState(filePath, FileState{
+		Size:         info.Size(),
+		ModifyTime:   oldModTime.UnixNano(),
+		IsListening:  true,
+		ProcessState: processStateFailed,
+	})
+	handler.handlers = []file_handlers.Interface{&blockingFinishedHandler{}}
+
+	handler.processListenFile(filePath, fileInfoWithModTime{
+		FileInfo: info,
+		modTime:  newModTime,
+	}, 24)
+
+	state, exists := handler.getFileState(filePath)
+	require.True(t, exists)
+	require.Equal(t, processStateUnprocessed, state.ProcessState)
+	require.Equal(t, newModTime.UnixNano(), state.ModifyTime)
+}
+
+func TestRestoreFileStatesPreservesConcurrentProcessState(t *testing.T) {
+	handler := newTestFileStateHandler(t)
+	filePath := filepath.Join(t.TempDir(), "restore.log")
+	original := FileState{
+		Size:         10,
+		ModifyTime:   20,
+		IsListening:  true,
+		ProcessState: processStateSeenOnce,
+	}
+	handler.setFileState(filePath, original)
+
+	checkpoints := make(map[string]fileStateCheckpoint)
+	handler.checkpointFileState(checkpoints, filePath)
+	require.NoError(t, handler.MarkProcessedFile(filePath))
+	handler.restoreFileStates(checkpoints)
+
+	state, exists := handler.getFileState(filePath)
+	require.True(t, exists)
+	require.Equal(t, processStateProcessed, state.ProcessState)
+	require.Equal(t, original.Size, state.Size)
+	require.Equal(t, original.ModifyTime, state.ModifyTime)
 }

--- a/internal/mod/rule/handler.go
+++ b/internal/mod/rule/handler.go
@@ -65,6 +65,8 @@ type CustomRuleHandler struct {
 	listenChan              chan string
 	ruleItemChan            chan rule_engine.RuleItem
 	engine                  Engine
+	inFlightMu              sync.Mutex
+	inFlightFiles           map[string]struct{}
 
 	// Master-slave components (optional)
 	slaveRegistry *master.SlaveRegistry
@@ -101,6 +103,7 @@ func NewRuleHandler(reqClient api.RequestClient, confManager config.ConfManager,
 		listenChan:              make(chan string, 1000),
 		ruleItemChan:            make(chan rule_engine.RuleItem, 1000),
 		engine:                  Engine{reqClient: reqClient, ruleDebounceTime: make(map[string]*time.Time)},
+		inFlightFiles:           make(map[string]struct{}),
 		pubSub:                  pubSub,
 		cleanCollectInfo: func(info model.CollectInfo) string {
 			return info.Clean()
@@ -309,17 +312,44 @@ func (c *CustomRuleHandler) sendFilesToBeProcessed(
 		file_state_handler.FilterIsListening(),
 		file_state_handler.FilterReadyToProcess(),
 	) {
+		if !c.addFileInFlight(fileState.Pathname) {
+			continue
+		}
+
 		select {
 		case c.listenChan <- fileState.Pathname:
 		case <-ctx.Done():
+			c.releaseFileInFlight(fileState.Pathname)
 			return
 		}
-
-		err := c.listenFileStateHandler.MarkProcessedFile(fileState.Pathname)
-		if err != nil {
-			log.Errorf("mark processed file: %v", err)
-		}
 	}
+}
+
+func (c *CustomRuleHandler) addFileInFlight(filename string) bool {
+	c.inFlightMu.Lock()
+	defer c.inFlightMu.Unlock()
+
+	if c.inFlightFiles == nil {
+		c.inFlightFiles = make(map[string]struct{})
+	}
+	if _, exists := c.inFlightFiles[filename]; exists {
+		return false
+	}
+	c.inFlightFiles[filename] = struct{}{}
+	return true
+}
+
+func (c *CustomRuleHandler) releaseFileInFlight(filename string) {
+	c.inFlightMu.Lock()
+	defer c.inFlightMu.Unlock()
+	delete(c.inFlightFiles, filename)
+}
+
+func (c *CustomRuleHandler) isFileInFlight(filename string) bool {
+	c.inFlightMu.Lock()
+	defer c.inFlightMu.Unlock()
+	_, exists := c.inFlightFiles[filename]
+	return exists
 }
 
 func (c *CustomRuleHandler) processListenedFilesAndSendMessages(
@@ -341,6 +371,7 @@ func (c *CustomRuleHandler) processListenedFilesAndSendMessages(
 			select {
 			case semaphore <- struct{}{}:
 			case <-ctx.Done():
+				c.releaseFileInFlight(fileToProcess)
 				wg.Wait()
 				return
 			}
@@ -349,8 +380,19 @@ func (c *CustomRuleHandler) processListenedFilesAndSendMessages(
 			go func(filename string) {
 				defer wg.Done()
 				defer func() { <-semaphore }() // release the semaphore
+				defer c.releaseFileInFlight(filename)
 
-				c.processFileWithRule(ctx, filename)
+				if err := c.processFileWithRule(ctx, filename); err != nil {
+					if !errors.Is(err, context.Canceled) {
+						log.Errorf("process file %s with rule: %v", filename, err)
+					}
+					return
+				}
+
+				if err := c.listenFileStateHandler.MarkProcessedFile(filename); err != nil {
+					log.Errorf("mark processed file: %v", err)
+					return
+				}
 				log.Infof("Finished processing file: %v", filename)
 			}(fileToProcess)
 		case <-ctx.Done():
@@ -363,16 +405,15 @@ func (c *CustomRuleHandler) processListenedFilesAndSendMessages(
 func (c *CustomRuleHandler) processFileWithRule(
 	ctx context.Context,
 	filename string,
-) {
+) error {
 	log.Infof("RuleEngine exec file: %v", filename)
 	handler := c.listenFileStateHandler.GetFileHandler(filename)
 	if handler == nil {
 		// this should not happen
-		log.Errorf("get file handler failed for file: %v", filename)
-		return
+		return errors.Errorf("get file handler failed for file: %v", filename)
 	}
 
-	handler.SendRuleItems(ctx, filename, c.engine.activeTopicSet(), c.ruleItemChan)
+	return handler.SendRuleItems(ctx, filename, c.engine.activeTopicSet(), c.ruleItemChan)
 }
 
 // scanCollectInfosAndHandle handles all collect info files within the collect info dir.

--- a/internal/mod/rule/handler.go
+++ b/internal/mod/rule/handler.go
@@ -523,13 +523,17 @@ func (c *CustomRuleHandler) scanCollectInfosAndHandle(
 		}
 
 		log.WithField("collectID", collectInfo.Id).Infof("Found collect info to handle")
-		c.handleCollectInfo(*collectInfo, *modConfig)
+		c.handleCollectInfo(ctx, *collectInfo, *modConfig)
 	}
 	log.Infof("Finished scanning collect info dir, found %d collect info files", len(collectInfoIds))
 }
 
 // handleCollectInfo handles a single the collect info.
-func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig config.DefaultModConfConfig) {
+func (c *CustomRuleHandler) handleCollectInfo(
+	ctx context.Context,
+	info model.CollectInfo,
+	modConfig config.DefaultModConfConfig,
+) {
 	ruleName, _ := info.DiagnosisTask["rule_name"].(string)
 	ruleDisplayName, _ := info.DiagnosisTask["rule_display_name"].(string)
 	collectLog := log.WithFields(log.Fields{
@@ -630,7 +634,7 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 	// Get slave files if master-slave is enabled
 	var slaveFiles []master.SlaveFileInfo
 	if c.slaveRegistry != nil && c.masterClient != nil && c.masterConfig != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), c.masterConfig.RequestTimeout)
+		requestCtx, cancel := context.WithTimeout(ctx, c.masterConfig.RequestTimeout)
 		defer cancel()
 
 		taskReq := &master.TaskRequest{
@@ -643,7 +647,7 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 			RecursivelyWalkDirs: modConfig.RecursivelyWalkDirs,
 		}
 
-		responses := c.masterClient.RequestAllSlaveFilesByContent(ctx, c.slaveRegistry, taskReq)
+		responses := c.masterClient.RequestAllSlaveFilesByContent(requestCtx, c.slaveRegistry, taskReq)
 		switch master.TaskResponsesTimeWindowErrorCode(responses) {
 		case master.TaskErrorCodeInvalidTimeWindow:
 			collectLog.Errorf("a slave rejected the collect info time window as permanently invalid, cleaning")

--- a/internal/mod/rule/handler.go
+++ b/internal/mod/rule/handler.go
@@ -130,7 +130,14 @@ func (c *CustomRuleHandler) Run(ctx context.Context) {
 			case <-t.C:
 				configTicker.Reset(config.ReloadRulesInterval)
 
-				appConfig := c.confManager.LoadWithRemote()
+				appConfig, err := c.confManager.LoadWithRemote()
+				if err != nil {
+					if appConfig == nil {
+						log.Errorf("load rule config: %v", err)
+						continue
+					}
+					log.Warnf("Unable to reload rule config, using last-known-good config: %v", err)
+				}
 				confConfig, ok := appConfig.Mod.Config.(config.DefaultModConfConfig)
 				if ok {
 					*modConfig = confConfig

--- a/internal/mod/rule/handler.go
+++ b/internal/mod/rule/handler.go
@@ -54,6 +54,11 @@ const (
 	collectFileStatePath = "collectFile.state.json"
 )
 
+type ruleItemEnvelope struct {
+	item     rule_engine.RuleItem
+	consumed chan struct{}
+}
+
 type CustomRuleHandler struct {
 	reqClient   api.RequestClient
 	confManager config.ConfManager
@@ -63,7 +68,7 @@ type CustomRuleHandler struct {
 	listenFileStateHandler  file_state_handler.FileStateHandler
 	collectFileStateHandler file_state_handler.FileStateHandler
 	listenChan              chan string
-	ruleItemChan            chan rule_engine.RuleItem
+	ruleItemChan            chan ruleItemEnvelope
 	engine                  Engine
 	inFlightMu              sync.Mutex
 	inFlightFiles           map[string]struct{}
@@ -101,7 +106,7 @@ func NewRuleHandler(reqClient api.RequestClient, confManager config.ConfManager,
 		listenFileStateHandler:  listenFileStateHandler,
 		collectFileStateHandler: collectFileStateHandler,
 		listenChan:              make(chan string, 1000),
-		ruleItemChan:            make(chan rule_engine.RuleItem, 1000),
+		ruleItemChan:            make(chan ruleItemEnvelope, 1000),
 		engine:                  Engine{reqClient: reqClient, ruleDebounceTime: make(map[string]*time.Time)},
 		inFlightFiles:           make(map[string]struct{}),
 		pubSub:                  pubSub,
@@ -218,8 +223,11 @@ func (c *CustomRuleHandler) Run(ctx context.Context) {
 	go func() {
 		for {
 			select {
-			case ruleItem := <-c.ruleItemChan:
-				c.engine.ConsumeNext(ruleItem)
+			case envelope := <-c.ruleItemChan:
+				c.engine.ConsumeNext(envelope.item)
+				if envelope.consumed != nil {
+					close(envelope.consumed)
+				}
 			case <-ctx.Done():
 				log.Infof("rule item channel closed")
 				return
@@ -279,7 +287,7 @@ func (c *CustomRuleHandler) handleSubMsg(ctx context.Context) {
 			}
 
 			select {
-			case c.ruleItemChan <- item:
+			case c.ruleItemChan <- ruleItemEnvelope{item: item}:
 				msg.Ack()
 			case <-ctx.Done():
 				return
@@ -413,7 +421,41 @@ func (c *CustomRuleHandler) processFileWithRule(
 		return errors.Errorf("get file handler failed for file: %v", filename)
 	}
 
-	return handler.SendRuleItems(ctx, filename, c.engine.activeTopicSet(), c.ruleItemChan)
+	localRuleItems := make(chan rule_engine.RuleItem)
+	handlerDone := make(chan error, 1)
+	go func() {
+		handlerDone <- handler.SendRuleItems(
+			ctx,
+			filename,
+			c.engine.activeTopicSet(),
+			localRuleItems,
+		)
+	}()
+
+	for {
+		select {
+		case item := <-localRuleItems:
+			consumed := make(chan struct{})
+			select {
+			case c.ruleItemChan <- ruleItemEnvelope{
+				item:     item,
+				consumed: consumed,
+			}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			select {
+			case <-consumed:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		case err := <-handlerDone:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }
 
 // scanCollectInfosAndHandle handles all collect info files within the collect info dir.

--- a/internal/mod/rule/handler.go
+++ b/internal/mod/rule/handler.go
@@ -17,6 +17,7 @@ package rule
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,8 +56,8 @@ const (
 )
 
 type ruleItemEnvelope struct {
-	item     rule_engine.RuleItem
-	consumed chan struct{}
+	item   rule_engine.RuleItem
+	result chan error
 }
 
 type CustomRuleHandler struct {
@@ -224,9 +225,9 @@ func (c *CustomRuleHandler) Run(ctx context.Context) {
 		for {
 			select {
 			case envelope := <-c.ruleItemChan:
-				c.engine.ConsumeNext(envelope.item)
-				if envelope.consumed != nil {
-					close(envelope.consumed)
+				consumeErr := c.engine.ConsumeNext(envelope.item)
+				if envelope.result != nil {
+					envelope.result <- consumeErr
 				}
 			case <-ctx.Done():
 				log.Infof("rule item channel closed")
@@ -391,8 +392,12 @@ func (c *CustomRuleHandler) processListenedFilesAndSendMessages(
 				defer c.releaseFileInFlight(filename)
 
 				if err := c.processFileWithRule(ctx, filename); err != nil {
-					if !errors.Is(err, context.Canceled) {
-						log.Errorf("process file %s with rule: %v", filename, err)
+					if !shouldMarkFileFailed(ctx, err) {
+						return
+					}
+					log.Errorf("process file %s with rule: %v", filename, err)
+					if markErr := c.listenFileStateHandler.MarkFailedFile(filename); markErr != nil {
+						log.Errorf("mark failed file %s: %v", filename, markErr)
 					}
 					return
 				}
@@ -408,6 +413,14 @@ func (c *CustomRuleHandler) processListenedFilesAndSendMessages(
 			return
 		}
 	}
+}
+
+func shouldMarkFileFailed(ctx context.Context, err error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	return !errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded)
 }
 
 func (c *CustomRuleHandler) processFileWithRule(
@@ -432,26 +445,33 @@ func (c *CustomRuleHandler) processFileWithRule(
 		)
 	}()
 
+	var consumeErr error
 	for {
 		select {
 		case item := <-localRuleItems:
-			consumed := make(chan struct{})
+			result := make(chan error, 1)
 			select {
 			case c.ruleItemChan <- ruleItemEnvelope{
-				item:     item,
-				consumed: consumed,
+				item:   item,
+				result: result,
 			}:
 			case <-ctx.Done():
 				return ctx.Err()
 			}
 
 			select {
-			case <-consumed:
+			case itemConsumeErr := <-result:
+				if itemConsumeErr != nil {
+					consumeErr = stderrors.Join(
+						consumeErr,
+						errors.Wrap(itemConsumeErr, "consume rule item"),
+					)
+				}
 			case <-ctx.Done():
 				return ctx.Err()
 			}
-		case err := <-handlerDone:
-			return err
+		case handlerErr := <-handlerDone:
+			return stderrors.Join(handlerErr, consumeErr)
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/internal/mod/rule/handler.go
+++ b/internal/mod/rule/handler.go
@@ -147,7 +147,11 @@ func (c *CustomRuleHandler) Run(ctx context.Context) {
 				apiRules, err := c.reqClient.ListDeviceDiagnosisRules(device.GetName())
 				if err != nil {
 					log.Errorf("list device diagnosis rules: %v", err)
-					c.errChan <- errors.Errorf("list device diagnosis rules: %v", err)
+					select {
+					case c.errChan <- errors.Errorf("list device diagnosis rules: %v", err):
+					case <-ctx.Done():
+						return
+					}
 					continue
 				}
 				log.Infof("received rules: %d", len(apiRules))
@@ -190,7 +194,7 @@ func (c *CustomRuleHandler) Run(ctx context.Context) {
 			case <-t.C:
 				listenTicker.Reset(config.RuleCheckListenFilesInterval)
 
-				c.sendFilesToBeProcessed(modConfig)
+				c.sendFilesToBeProcessed(ctx, modConfig)
 			case <-ctx.Done():
 				return
 			}
@@ -222,8 +226,7 @@ func (c *CustomRuleHandler) Run(ctx context.Context) {
 			case <-t.C:
 				t.Reset(config.RuleScanCollectInfosInterval)
 
-				//nolint: contextcheck// context is checked in the parent goroutine
-				c.scanCollectInfosAndHandle(modConfig)
+				c.scanCollectInfosAndHandle(ctx, modConfig)
 			case <-ctx.Done():
 				log.Infof("collect info handler stopped")
 				return
@@ -241,7 +244,10 @@ func (c *CustomRuleHandler) handleSubMsg(ctx context.Context) {
 	messages, err := c.pubSub.Subscribe(ctx, constant.TopicRuleMsg)
 	if err != nil {
 		log.Errorf("subscribe to rule message: %v", err)
-		c.errChan <- errors.Wrap(err, "subscribe to rule message")
+		select {
+		case c.errChan <- errors.Wrap(err, "subscribe to rule message"):
+		case <-ctx.Done():
+		}
 		return
 	}
 
@@ -274,7 +280,10 @@ func (c *CustomRuleHandler) handleSubMsg(ctx context.Context) {
 	}
 }
 
-func (c *CustomRuleHandler) sendFilesToBeProcessed(modConfig *config.DefaultModConfConfig) {
+func (c *CustomRuleHandler) sendFilesToBeProcessed(
+	ctx context.Context,
+	modConfig *config.DefaultModConfConfig,
+) {
 	if len(modConfig.ListenDirs) == 0 {
 		return
 	}
@@ -293,11 +302,16 @@ func (c *CustomRuleHandler) sendFilesToBeProcessed(modConfig *config.DefaultModC
 		file_state_handler.FilterIsListening(),
 		file_state_handler.FilterReadyToProcess(),
 	) {
+		select {
+		case c.listenChan <- fileState.Pathname:
+		case <-ctx.Done():
+			return
+		}
+
 		err := c.listenFileStateHandler.MarkProcessedFile(fileState.Pathname)
 		if err != nil {
 			log.Errorf("mark processed file: %v", err)
 		}
-		c.listenChan <- fileState.Pathname
 	}
 }
 
@@ -317,14 +331,19 @@ func (c *CustomRuleHandler) processListenedFilesAndSendMessages(
 				return
 			}
 
-			semaphore <- struct{}{}
+			select {
+			case semaphore <- struct{}{}:
+			case <-ctx.Done():
+				wg.Wait()
+				return
+			}
 
 			wg.Add(1)
 			go func(filename string) {
 				defer wg.Done()
 				defer func() { <-semaphore }() // release the semaphore
 
-				c.processFileWithRule(filename)
+				c.processFileWithRule(ctx, filename)
 				log.Infof("Finished processing file: %v", filename)
 			}(fileToProcess)
 		case <-ctx.Done():
@@ -335,6 +354,7 @@ func (c *CustomRuleHandler) processListenedFilesAndSendMessages(
 }
 
 func (c *CustomRuleHandler) processFileWithRule(
+	ctx context.Context,
 	filename string,
 ) {
 	log.Infof("RuleEngine exec file: %v", filename)
@@ -345,11 +365,14 @@ func (c *CustomRuleHandler) processFileWithRule(
 		return
 	}
 
-	handler.SendRuleItems(filename, c.engine.activeTopicSet(), c.ruleItemChan)
+	handler.SendRuleItems(ctx, filename, c.engine.activeTopicSet(), c.ruleItemChan)
 }
 
 // scanCollectInfosAndHandle handles all collect info files within the collect info dir.
-func (c *CustomRuleHandler) scanCollectInfosAndHandle(modConfig *config.DefaultModConfConfig) {
+func (c *CustomRuleHandler) scanCollectInfosAndHandle(
+	ctx context.Context,
+	modConfig *config.DefaultModConfConfig,
+) {
 	log.Infof("Starts to scan collect info dir")
 
 	// Search for files under the collect info dir and handles them
@@ -357,7 +380,10 @@ func (c *CustomRuleHandler) scanCollectInfosAndHandle(modConfig *config.DefaultM
 	entries, err := os.ReadDir(collectInfoDir)
 	if err != nil {
 		log.Errorf("read collect info dir: %v", err)
-		c.errChan <- errors.Wrap(err, "read collect info dir")
+		select {
+		case c.errChan <- errors.Wrap(err, "read collect info dir"):
+		case <-ctx.Done():
+		}
 		return
 	}
 
@@ -378,10 +404,18 @@ func (c *CustomRuleHandler) scanCollectInfosAndHandle(modConfig *config.DefaultM
 
 	log.Infof("Found %d collect info files", len(collectInfoIds))
 	for _, collectInfoId := range collectInfoIds {
+		if ctx.Err() != nil {
+			return
+		}
+
 		collectInfo := &model.CollectInfo{}
 		if err := collectInfo.Load(collectInfoId); err != nil {
 			log.Errorf("load collect info: %v", err)
-			c.errChan <- errors.Wrap(err, "load collect info")
+			select {
+			case c.errChan <- errors.Wrap(err, "load collect info"):
+			case <-ctx.Done():
+				return
+			}
 			continue
 		}
 

--- a/internal/mod/rule/handler_test.go
+++ b/internal/mod/rule/handler_test.go
@@ -298,6 +298,43 @@ func (h *resultFileHandler) SendRuleItems(
 	return h.err
 }
 
+type itemProducingFileHandler struct {
+	produced chan struct{}
+}
+
+func (h *itemProducingFileHandler) CheckFilePath(string) bool {
+	return true
+}
+
+func (h *itemProducingFileHandler) GetStartTimeEndTime(string) (*time.Time, *time.Time, error) {
+	return nil, nil, nil
+}
+
+func (h *itemProducingFileHandler) GetFileSize(string) (int64, error) {
+	return 0, nil
+}
+
+func (h *itemProducingFileHandler) IsFinished(string) bool {
+	return true
+}
+
+func (h *itemProducingFileHandler) SendRuleItems(
+	ctx context.Context,
+	filename string,
+	_ mapset.Set[string],
+	ruleItems chan<- rule_engine.RuleItem,
+) error {
+	select {
+	case ruleItems <- rule_engine.RuleItem{Source: filename}:
+		if h.produced != nil {
+			close(h.produced)
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func TestSendFilesToBeProcessedCancellationDoesNotMarkUnqueuedFile(t *testing.T) {
 	stateHandler := &fakeFileStateHandler{
 		files: []file_state_handler.FileState{{Pathname: "pending.log"}},
@@ -347,7 +384,7 @@ func TestProcessListenedFilesCancellationInterruptsSemaphoreWait(t *testing.T) {
 	handler := &CustomRuleHandler{
 		listenFileStateHandler: stateHandler,
 		listenChan:             make(chan string, 2),
-		ruleItemChan:           make(chan rule_engine.RuleItem),
+		ruleItemChan:           make(chan ruleItemEnvelope),
 	}
 	handler.listenChan <- "first.log"
 	handler.listenChan <- "second.log"
@@ -382,7 +419,7 @@ func TestCancelledFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
 	handler := &CustomRuleHandler{
 		listenFileStateHandler: stateHandler,
 		listenChan:             make(chan string, 1),
-		ruleItemChan:           make(chan rule_engine.RuleItem),
+		ruleItemChan:           make(chan ruleItemEnvelope),
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -427,7 +464,7 @@ func TestCompletedFileProcessingMarksFileProcessed(t *testing.T) {
 	handler := &CustomRuleHandler{
 		listenFileStateHandler: stateHandler,
 		listenChan:             make(chan string, 1),
-		ruleItemChan:           make(chan rule_engine.RuleItem),
+		ruleItemChan:           make(chan ruleItemEnvelope),
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -467,7 +504,7 @@ func TestFailedFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
 	handler := &CustomRuleHandler{
 		listenFileStateHandler: stateHandler,
 		listenChan:             make(chan string, 1),
-		ruleItemChan:           make(chan rule_engine.RuleItem),
+		ruleItemChan:           make(chan ruleItemEnvelope),
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -516,4 +553,105 @@ func TestSendFilesToBeProcessedDoesNotEnqueueInFlightFileTwice(t *testing.T) {
 	require.Len(t, handler.listenChan, 1)
 	require.Zero(t, stateHandler.processedCount())
 	require.True(t, handler.isFileInFlight("pending.log"))
+}
+
+func TestProducedRuleItemWithoutConsumerAckIsNotMarkedProcessedOnCancel(t *testing.T) {
+	produced := make(chan struct{})
+	stateHandler := &fakeFileStateHandler{
+		files: []file_state_handler.FileState{{Pathname: "pending-ack.log"}},
+		fileHandler: &itemProducingFileHandler{
+			produced: produced,
+		},
+	}
+	handler := &CustomRuleHandler{
+		listenFileStateHandler: stateHandler,
+		listenChan:             make(chan string, 1),
+		ruleItemChan:           make(chan ruleItemEnvelope, 1),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
+		ListenDirs: []string{t.TempDir()},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.processListenedFilesAndSendMessages(ctx, 1)
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-produced:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	var envelope ruleItemEnvelope
+	select {
+	case envelope = <-handler.ruleItemChan:
+	case <-time.After(time.Second):
+		t.Fatal("rule item was not forwarded to the consumer channel")
+	}
+	require.NotNil(t, envelope.consumed)
+	require.Zero(t, stateHandler.processedCount())
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Zero(t, stateHandler.processedCount())
+}
+
+func TestProducedRuleItemIsMarkedProcessedOnlyAfterConsumerAck(t *testing.T) {
+	stateHandler := &fakeFileStateHandler{
+		files:       []file_state_handler.FileState{{Pathname: "acked.log"}},
+		fileHandler: &itemProducingFileHandler{},
+	}
+	handler := &CustomRuleHandler{
+		listenFileStateHandler: stateHandler,
+		listenChan:             make(chan string, 1),
+		ruleItemChan:           make(chan ruleItemEnvelope, 1),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
+		ListenDirs: []string{t.TempDir()},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.processListenedFilesAndSendMessages(ctx, 1)
+	}()
+
+	var envelope ruleItemEnvelope
+	select {
+	case envelope = <-handler.ruleItemChan:
+	case <-time.After(time.Second):
+		t.Fatal("rule item was not forwarded to the consumer channel")
+	}
+	require.NotNil(t, envelope.consumed)
+	require.Zero(t, stateHandler.processedCount())
+
+	close(envelope.consumed)
+	require.Eventually(t, func() bool {
+		return stateHandler.processedCount() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/mod/rule/handler_test.go
+++ b/internal/mod/rule/handler_test.go
@@ -16,6 +16,7 @@ package rule
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -233,6 +234,7 @@ func (f *fakeFileStateHandler) processedCount() int {
 }
 
 type cancellationBlockingHandler struct {
+	started chan struct{}
 }
 
 func (h *cancellationBlockingHandler) CheckFilePath(string) bool {
@@ -256,8 +258,44 @@ func (h *cancellationBlockingHandler) SendRuleItems(
 	_ string,
 	_ mapset.Set[string],
 	_ chan<- rule_engine.RuleItem,
-) {
+) error {
+	if h.started != nil {
+		select {
+		case h.started <- struct{}{}:
+		default:
+		}
+	}
 	<-ctx.Done()
+	return ctx.Err()
+}
+
+type resultFileHandler struct {
+	err error
+}
+
+func (h *resultFileHandler) CheckFilePath(string) bool {
+	return true
+}
+
+func (h *resultFileHandler) GetStartTimeEndTime(string) (*time.Time, *time.Time, error) {
+	return nil, nil, nil
+}
+
+func (h *resultFileHandler) GetFileSize(string) (int64, error) {
+	return 0, nil
+}
+
+func (h *resultFileHandler) IsFinished(string) bool {
+	return true
+}
+
+func (h *resultFileHandler) SendRuleItems(
+	context.Context,
+	string,
+	mapset.Set[string],
+	chan<- rule_engine.RuleItem,
+) error {
+	return h.err
 }
 
 func TestSendFilesToBeProcessedCancellationDoesNotMarkUnqueuedFile(t *testing.T) {
@@ -271,6 +309,7 @@ func TestSendFilesToBeProcessedCancellationDoesNotMarkUnqueuedFile(t *testing.T)
 		listenChan:             listenChan,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	done := make(chan struct{})
 	listenDir := t.TempDir()
 
@@ -298,6 +337,7 @@ func TestSendFilesToBeProcessedCancellationDoesNotMarkUnqueuedFile(t *testing.T)
 		}
 	}, time.Second, 10*time.Millisecond)
 	require.Zero(t, stateHandler.processedCount())
+	require.False(t, handler.isFileInFlight("pending.log"))
 }
 
 func TestProcessListenedFilesCancellationInterruptsSemaphoreWait(t *testing.T) {
@@ -313,6 +353,7 @@ func TestProcessListenedFilesCancellationInterruptsSemaphoreWait(t *testing.T) {
 	handler.listenChan <- "second.log"
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -330,4 +371,149 @@ func TestProcessListenedFilesCancellationInterruptsSemaphoreWait(t *testing.T) {
 			return false
 		}
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestCancelledFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
+	started := make(chan struct{}, 1)
+	stateHandler := &fakeFileStateHandler{
+		files:       []file_state_handler.FileState{{Pathname: "pending.log"}},
+		fileHandler: &cancellationBlockingHandler{started: started},
+	}
+	handler := &CustomRuleHandler{
+		listenFileStateHandler: stateHandler,
+		listenChan:             make(chan string, 1),
+		ruleItemChan:           make(chan rule_engine.RuleItem),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
+		ListenDirs: []string{t.TempDir()},
+	})
+	require.Zero(t, stateHandler.processedCount())
+	require.True(t, handler.isFileInFlight("pending.log"))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.processListenedFilesAndSendMessages(ctx, 1)
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Zero(t, stateHandler.processedCount())
+	require.False(t, handler.isFileInFlight("pending.log"))
+}
+
+func TestCompletedFileProcessingMarksFileProcessed(t *testing.T) {
+	stateHandler := &fakeFileStateHandler{
+		files:       []file_state_handler.FileState{{Pathname: "completed.log"}},
+		fileHandler: &resultFileHandler{},
+	}
+	handler := &CustomRuleHandler{
+		listenFileStateHandler: stateHandler,
+		listenChan:             make(chan string, 1),
+		ruleItemChan:           make(chan rule_engine.RuleItem),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
+		ListenDirs: []string{t.TempDir()},
+	})
+	require.Zero(t, stateHandler.processedCount())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.processListenedFilesAndSendMessages(ctx, 1)
+	}()
+	require.Eventually(t, func() bool {
+		return stateHandler.processedCount() == 1
+	}, time.Second, 10*time.Millisecond)
+	require.False(t, handler.isFileInFlight("completed.log"))
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestFailedFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
+	stateHandler := &fakeFileStateHandler{
+		files: []file_state_handler.FileState{{Pathname: "failed.log"}},
+		fileHandler: &resultFileHandler{
+			err: errors.New("read failed"),
+		},
+	}
+	handler := &CustomRuleHandler{
+		listenFileStateHandler: stateHandler,
+		listenChan:             make(chan string, 1),
+		ruleItemChan:           make(chan rule_engine.RuleItem),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
+		ListenDirs: []string{t.TempDir()},
+	})
+	require.True(t, handler.isFileInFlight("failed.log"))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.processListenedFilesAndSendMessages(ctx, 1)
+	}()
+	require.Eventually(t, func() bool {
+		return !handler.isFileInFlight("failed.log")
+	}, time.Second, 10*time.Millisecond)
+
+	require.Zero(t, stateHandler.processedCount())
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestSendFilesToBeProcessedDoesNotEnqueueInFlightFileTwice(t *testing.T) {
+	stateHandler := &fakeFileStateHandler{
+		files: []file_state_handler.FileState{{Pathname: "pending.log"}},
+	}
+	handler := &CustomRuleHandler{
+		listenFileStateHandler: stateHandler,
+		listenChan:             make(chan string, 2),
+	}
+	ctx := context.Background()
+	modConfig := &config.DefaultModConfConfig{
+		ListenDirs: []string{t.TempDir()},
+	}
+
+	handler.sendFilesToBeProcessed(ctx, modConfig)
+	handler.sendFilesToBeProcessed(ctx, modConfig)
+
+	require.Len(t, handler.listenChan, 1)
+	require.Zero(t, stateHandler.processedCount())
+	require.True(t, handler.isFileInFlight("pending.log"))
 }

--- a/internal/mod/rule/handler_test.go
+++ b/internal/mod/rule/handler_test.go
@@ -190,6 +190,10 @@ func (*recordingRuleFileStateHandler) MarkProcessedFile(string) error {
 	return nil
 }
 
+func (*recordingRuleFileStateHandler) MarkFailedFile(string) error {
+	return nil
+}
+
 func (*recordingRuleFileStateHandler) GetFileHandler(string) file_handlers.Interface {
 	return nil
 }
@@ -200,6 +204,7 @@ type fakeFileStateHandler struct {
 
 	mu            sync.Mutex
 	processedFile []string
+	failedFile    []string
 }
 
 func (f *fakeFileStateHandler) UpdateListenDirs(config.DefaultModConfConfig) error {
@@ -225,6 +230,13 @@ func (f *fakeFileStateHandler) MarkProcessedFile(filename string) error {
 	return nil
 }
 
+func (f *fakeFileStateHandler) MarkFailedFile(filename string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failedFile = append(f.failedFile, filename)
+	return nil
+}
+
 func (f *fakeFileStateHandler) GetFileHandler(string) file_handlers.Interface {
 	return f.fileHandler
 }
@@ -235,8 +247,15 @@ func (f *fakeFileStateHandler) processedCount() int {
 	return len(f.processedFile)
 }
 
+func (f *fakeFileStateHandler) failedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.failedFile)
+}
+
 type cancellationBlockingHandler struct {
 	started chan struct{}
+	err     error
 }
 
 func (h *cancellationBlockingHandler) CheckFilePath(string) bool {
@@ -268,6 +287,9 @@ func (h *cancellationBlockingHandler) SendRuleItems(
 		}
 	}
 	<-ctx.Done()
+	if h.err != nil {
+		return h.err
+	}
 	return ctx.Err()
 }
 
@@ -327,7 +349,10 @@ func (h *itemProducingFileHandler) SendRuleItems(
 	ruleItems chan<- rule_engine.RuleItem,
 ) error {
 	select {
-	case ruleItems <- rule_engine.RuleItem{Source: filename}:
+	case ruleItems <- rule_engine.RuleItem{
+		Source: filename,
+		Topic:  "/fault",
+	}:
 		if h.produced != nil {
 			close(h.produced)
 		}
@@ -335,6 +360,32 @@ func (h *itemProducingFileHandler) SendRuleItems(
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+type multiItemFileHandler struct {
+	resultFileHandler
+	done chan struct{}
+}
+
+func (h *multiItemFileHandler) SendRuleItems(
+	ctx context.Context,
+	filename string,
+	_ mapset.Set[string],
+	ruleItems chan<- rule_engine.RuleItem,
+) error {
+	defer close(h.done)
+	for index := 1; index <= 2; index++ {
+		select {
+		case ruleItems <- rule_engine.RuleItem{
+			Msg:    map[string]interface{}{"index": index},
+			Source: filename,
+			Topic:  "/fault",
+		}:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
 }
 
 func TestSendFilesToBeProcessedCancellationDoesNotMarkUnqueuedFile(t *testing.T) {
@@ -378,6 +429,7 @@ func TestSendFilesToBeProcessedCancellationDoesNotMarkUnqueuedFile(t *testing.T)
 		}
 	}, time.Second, 10*time.Millisecond)
 	require.Zero(t, stateHandler.processedCount())
+	require.Zero(t, stateHandler.failedCount())
 	require.False(t, handler.isFileInFlight("pending.log"))
 }
 
@@ -461,7 +513,60 @@ func TestCancelledFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
 		}
 	}, time.Second, 10*time.Millisecond)
 	require.Zero(t, stateHandler.processedCount())
+	require.Zero(t, stateHandler.failedCount())
 	require.False(t, handler.isFileInFlight("pending.log"))
+}
+
+func TestCancellationDoesNotMarkFailedWhenHandlerReturnsSentinelError(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{}, 1)
+	sentinelErr := errors.New("handler lost cancellation cause")
+	stateHandler := &fakeFileStateHandler{
+		files: []file_state_handler.FileState{{Pathname: "cancelled-sentinel.log"}},
+		fileHandler: &cancellationBlockingHandler{
+			started: started,
+			err:     sentinelErr,
+		},
+	}
+	handler := &CustomRuleHandler{
+		listenFileStateHandler: stateHandler,
+		listenChan:             make(chan string, 1),
+		ruleItemChan:           make(chan ruleItemEnvelope),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
+		ListenDirs: []string{t.TempDir()},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.processListenedFilesAndSendMessages(ctx, 1)
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	require.False(t, shouldMarkFileFailed(ctx, sentinelErr))
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Zero(t, stateHandler.processedCount())
+	require.Zero(t, stateHandler.failedCount())
+	require.False(t, handler.isFileInFlight("cancelled-sentinel.log"))
 }
 
 func TestCompletedFileProcessingMarksFileProcessed(t *testing.T) {
@@ -491,6 +596,7 @@ func TestCompletedFileProcessingMarksFileProcessed(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return stateHandler.processedCount() == 1
 	}, time.Second, 10*time.Millisecond)
+	require.Zero(t, stateHandler.failedCount())
 	require.False(t, handler.isFileInFlight("completed.log"))
 
 	cancel()
@@ -531,7 +637,8 @@ func TestFailedFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
 		handler.processListenedFilesAndSendMessages(ctx, 1)
 	}()
 	require.Eventually(t, func() bool {
-		return !handler.isFileInFlight("failed.log")
+		return stateHandler.failedCount() == 1 &&
+			!handler.isFileInFlight("failed.log")
 	}, time.Second, 10*time.Millisecond)
 
 	require.Zero(t, stateHandler.processedCount())
@@ -610,7 +717,7 @@ func TestProducedRuleItemWithoutConsumerAckIsNotMarkedProcessedOnCancel(t *testi
 	case <-time.After(time.Second):
 		t.Fatal("rule item was not forwarded to the consumer channel")
 	}
-	require.NotNil(t, envelope.consumed)
+	require.NotNil(t, envelope.result)
 	require.Zero(t, stateHandler.processedCount())
 
 	cancel()
@@ -623,6 +730,12 @@ func TestProducedRuleItemWithoutConsumerAckIsNotMarkedProcessedOnCancel(t *testi
 		}
 	}, time.Second, 10*time.Millisecond)
 	require.Zero(t, stateHandler.processedCount())
+	require.Zero(t, stateHandler.failedCount())
+	select {
+	case envelope.result <- nil:
+	case <-time.After(time.Second):
+		t.Fatal("consumer result handshake blocked after worker cancellation")
+	}
 }
 
 func TestProducedRuleItemIsMarkedProcessedOnlyAfterConsumerAck(t *testing.T) {
@@ -655,18 +768,173 @@ func TestProducedRuleItemIsMarkedProcessedOnlyAfterConsumerAck(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("rule item was not forwarded to the consumer channel")
 	}
-	require.NotNil(t, envelope.consumed)
+	require.NotNil(t, envelope.result)
 	require.Zero(t, stateHandler.processedCount())
 
-	close(envelope.consumed)
+	envelope.result <- nil
 	require.Eventually(t, func() bool {
 		return stateHandler.processedCount() == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Zero(t, stateHandler.failedCount())
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestRuleItemConsumptionErrorMarksFileFailed(t *testing.T) {
+	t.Parallel()
+
+	consumeErr := errors.New("consume failed")
+	action, err := rule_engine.NewAction(
+		"failing-action",
+		map[string]interface{}{},
+		func(map[string]interface{}) error {
+			return consumeErr
+		},
+	)
+	require.NoError(t, err)
+	stateHandler := &fakeFileStateHandler{
+		files:       []file_state_handler.FileState{{Pathname: "consume-error.log"}},
+		fileHandler: &itemProducingFileHandler{},
+	}
+	handler := &CustomRuleHandler{
+		listenFileStateHandler: stateHandler,
+		listenChan:             make(chan string, 1),
+		ruleItemChan:           make(chan ruleItemEnvelope, 1),
+		engine: Engine{
+			rules:            []*rule_engine.Rule{testRuntimeRule(t, action)},
+			ruleDebounceTime: make(map[string]*time.Time),
+			publishCollectInfoFn: func(string) error {
+				return nil
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
+		ListenDirs: []string{t.TempDir()},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.processListenedFilesAndSendMessages(ctx, 1)
+	}()
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		select {
+		case envelope := <-handler.ruleItemChan:
+			envelope.result <- handler.engine.ConsumeNext(envelope.item)
+		case <-ctx.Done():
+		}
+	}()
+
+	require.Eventually(t, func() bool {
+		return stateHandler.failedCount() == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Zero(t, stateHandler.processedCount())
+	require.Eventually(t, func() bool {
+		select {
+		case <-consumerDone:
+			return true
+		default:
+			return false
+		}
 	}, time.Second, 10*time.Millisecond)
 
 	cancel()
 	require.Eventually(t, func() bool {
 		select {
 		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestRuleItemConsumptionErrorDrainsRemainingHandlerItems(t *testing.T) {
+	t.Parallel()
+
+	producerDone := make(chan struct{})
+	stateHandler := &fakeFileStateHandler{
+		files: []file_state_handler.FileState{{Pathname: "multi-item.log"}},
+		fileHandler: &multiItemFileHandler{
+			done: producerDone,
+		},
+	}
+	handler := &CustomRuleHandler{
+		listenFileStateHandler: stateHandler,
+		listenChan:             make(chan string, 1),
+		ruleItemChan:           make(chan ruleItemEnvelope, 1),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
+		ListenDirs: []string{t.TempDir()},
+	})
+
+	workerDone := make(chan struct{})
+	go func() {
+		defer close(workerDone)
+		handler.processListenedFilesAndSendMessages(ctx, 1)
+	}()
+
+	var consumedIndexes []int
+	consumerDone := make(chan struct{})
+	firstConsumeErr := errors.New("first item failed")
+	go func() {
+		defer close(consumerDone)
+		for index := 0; index < 2; index++ {
+			select {
+			case envelope := <-handler.ruleItemChan:
+				itemIndex, _ := envelope.item.Msg["index"].(int)
+				consumedIndexes = append(consumedIndexes, itemIndex)
+				if index == 0 {
+					envelope.result <- firstConsumeErr
+				} else {
+					envelope.result <- nil
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-producerDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		select {
+		case <-consumerDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, []int{1, 2}, consumedIndexes)
+	require.Eventually(t, func() bool {
+		return stateHandler.failedCount() == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Zero(t, stateHandler.processedCount())
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-workerDone:
 			return true
 		default:
 			return false

--- a/internal/mod/rule/handler_test.go
+++ b/internal/mod/rule/handler_test.go
@@ -16,6 +16,7 @@ package rule
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,6 +25,9 @@ import (
 	"github.com/coscene-io/coscout/internal/mod/rule/file_handlers"
 	"github.com/coscene-io/coscout/internal/mod/rule/file_state_handler"
 	"github.com/coscene-io/coscout/internal/model"
+	"github.com/coscene-io/coscout/pkg/rule_engine"
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleCollectInfoTimeWindowLifecycle(t *testing.T) {
@@ -185,4 +189,145 @@ func (*recordingRuleFileStateHandler) MarkProcessedFile(string) error {
 
 func (*recordingRuleFileStateHandler) GetFileHandler(string) file_handlers.Interface {
 	return nil
+}
+
+type fakeFileStateHandler struct {
+	files       []file_state_handler.FileState
+	fileHandler file_handlers.Interface
+
+	mu            sync.Mutex
+	processedFile []string
+}
+
+func (f *fakeFileStateHandler) UpdateListenDirs(config.DefaultModConfConfig) error {
+	return nil
+}
+
+func (f *fakeFileStateHandler) UpdateCollectDirs([]string, config.DefaultModConfConfig) error {
+	return nil
+}
+
+func (f *fakeFileStateHandler) Files(...file_state_handler.FileFilter) []file_state_handler.FileState {
+	return f.files
+}
+
+func (f *fakeFileStateHandler) UpdateFilesProcessState() error {
+	return nil
+}
+
+func (f *fakeFileStateHandler) MarkProcessedFile(filename string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.processedFile = append(f.processedFile, filename)
+	return nil
+}
+
+func (f *fakeFileStateHandler) GetFileHandler(string) file_handlers.Interface {
+	return f.fileHandler
+}
+
+func (f *fakeFileStateHandler) processedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.processedFile)
+}
+
+type cancellationBlockingHandler struct {
+}
+
+func (h *cancellationBlockingHandler) CheckFilePath(string) bool {
+	return true
+}
+
+func (h *cancellationBlockingHandler) GetStartTimeEndTime(string) (*time.Time, *time.Time, error) {
+	return nil, nil, nil
+}
+
+func (h *cancellationBlockingHandler) GetFileSize(string) (int64, error) {
+	return 0, nil
+}
+
+func (h *cancellationBlockingHandler) IsFinished(string) bool {
+	return true
+}
+
+func (h *cancellationBlockingHandler) SendRuleItems(
+	ctx context.Context,
+	_ string,
+	_ mapset.Set[string],
+	_ chan<- rule_engine.RuleItem,
+) {
+	<-ctx.Done()
+}
+
+func TestSendFilesToBeProcessedCancellationDoesNotMarkUnqueuedFile(t *testing.T) {
+	stateHandler := &fakeFileStateHandler{
+		files: []file_state_handler.FileState{{Pathname: "pending.log"}},
+	}
+	listenChan := make(chan string, 1)
+	listenChan <- "already-queued.log"
+	handler := &CustomRuleHandler{
+		listenFileStateHandler: stateHandler,
+		listenChan:             listenChan,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	listenDir := t.TempDir()
+
+	go func() {
+		defer close(done)
+		handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
+			ListenDirs: []string{listenDir},
+		})
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("sendFilesToBeProcessed returned before the full channel was cancelled")
+	case <-time.After(50 * time.Millisecond):
+	}
+	require.Zero(t, stateHandler.processedCount())
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Zero(t, stateHandler.processedCount())
+}
+
+func TestProcessListenedFilesCancellationInterruptsSemaphoreWait(t *testing.T) {
+	stateHandler := &fakeFileStateHandler{
+		fileHandler: &cancellationBlockingHandler{},
+	}
+	handler := &CustomRuleHandler{
+		listenFileStateHandler: stateHandler,
+		listenChan:             make(chan string, 2),
+		ruleItemChan:           make(chan rule_engine.RuleItem),
+	}
+	handler.listenChan <- "first.log"
+	handler.listenChan <- "second.log"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.processListenedFilesAndSendMessages(ctx, 1)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/mod/rule/handler_test.go
+++ b/internal/mod/rule/handler_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var errTestReadFailed = errors.New("read failed")
+
 func TestHandleCollectInfoTimeWindowLifecycle(t *testing.T) {
 	t.Parallel()
 
@@ -101,7 +103,7 @@ func TestHandleCollectInfoTimeWindowLifecycle(t *testing.T) {
 				},
 			}
 
-			handler.handleCollectInfo(info, config.DefaultModConfConfig{})
+			handler.handleCollectInfo(t.Context(), info, config.DefaultModConfConfig{})
 
 			if cleaned != tc.wantClean {
 				t.Fatalf("cleaned = %v, want %v", cleaned, tc.wantClean)
@@ -336,6 +338,8 @@ func (h *itemProducingFileHandler) SendRuleItems(
 }
 
 func TestSendFilesToBeProcessedCancellationDoesNotMarkUnqueuedFile(t *testing.T) {
+	t.Parallel()
+
 	stateHandler := &fakeFileStateHandler{
 		files: []file_state_handler.FileState{{Pathname: "pending.log"}},
 	}
@@ -345,7 +349,7 @@ func TestSendFilesToBeProcessedCancellationDoesNotMarkUnqueuedFile(t *testing.T)
 		listenFileStateHandler: stateHandler,
 		listenChan:             listenChan,
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	done := make(chan struct{})
 	listenDir := t.TempDir()
@@ -378,6 +382,8 @@ func TestSendFilesToBeProcessedCancellationDoesNotMarkUnqueuedFile(t *testing.T)
 }
 
 func TestProcessListenedFilesCancellationInterruptsSemaphoreWait(t *testing.T) {
+	t.Parallel()
+
 	stateHandler := &fakeFileStateHandler{
 		fileHandler: &cancellationBlockingHandler{},
 	}
@@ -389,7 +395,7 @@ func TestProcessListenedFilesCancellationInterruptsSemaphoreWait(t *testing.T) {
 	handler.listenChan <- "first.log"
 	handler.listenChan <- "second.log"
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	done := make(chan struct{})
 	go func() {
@@ -411,6 +417,8 @@ func TestProcessListenedFilesCancellationInterruptsSemaphoreWait(t *testing.T) {
 }
 
 func TestCancelledFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
+	t.Parallel()
+
 	started := make(chan struct{}, 1)
 	stateHandler := &fakeFileStateHandler{
 		files:       []file_state_handler.FileState{{Pathname: "pending.log"}},
@@ -421,7 +429,7 @@ func TestCancelledFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
 		listenChan:             make(chan string, 1),
 		ruleItemChan:           make(chan ruleItemEnvelope),
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
 		ListenDirs: []string{t.TempDir()},
@@ -457,6 +465,8 @@ func TestCancelledFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
 }
 
 func TestCompletedFileProcessingMarksFileProcessed(t *testing.T) {
+	t.Parallel()
+
 	stateHandler := &fakeFileStateHandler{
 		files:       []file_state_handler.FileState{{Pathname: "completed.log"}},
 		fileHandler: &resultFileHandler{},
@@ -466,7 +476,7 @@ func TestCompletedFileProcessingMarksFileProcessed(t *testing.T) {
 		listenChan:             make(chan string, 1),
 		ruleItemChan:           make(chan ruleItemEnvelope),
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
 		ListenDirs: []string{t.TempDir()},
@@ -495,10 +505,12 @@ func TestCompletedFileProcessingMarksFileProcessed(t *testing.T) {
 }
 
 func TestFailedFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
+	t.Parallel()
+
 	stateHandler := &fakeFileStateHandler{
 		files: []file_state_handler.FileState{{Pathname: "failed.log"}},
 		fileHandler: &resultFileHandler{
-			err: errors.New("read failed"),
+			err: errTestReadFailed,
 		},
 	}
 	handler := &CustomRuleHandler{
@@ -506,7 +518,7 @@ func TestFailedFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
 		listenChan:             make(chan string, 1),
 		ruleItemChan:           make(chan ruleItemEnvelope),
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
 		ListenDirs: []string{t.TempDir()},
@@ -535,6 +547,8 @@ func TestFailedFileProcessingDoesNotMarkFileProcessed(t *testing.T) {
 }
 
 func TestSendFilesToBeProcessedDoesNotEnqueueInFlightFileTwice(t *testing.T) {
+	t.Parallel()
+
 	stateHandler := &fakeFileStateHandler{
 		files: []file_state_handler.FileState{{Pathname: "pending.log"}},
 	}
@@ -542,7 +556,7 @@ func TestSendFilesToBeProcessedDoesNotEnqueueInFlightFileTwice(t *testing.T) {
 		listenFileStateHandler: stateHandler,
 		listenChan:             make(chan string, 2),
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	modConfig := &config.DefaultModConfConfig{
 		ListenDirs: []string{t.TempDir()},
 	}
@@ -556,6 +570,8 @@ func TestSendFilesToBeProcessedDoesNotEnqueueInFlightFileTwice(t *testing.T) {
 }
 
 func TestProducedRuleItemWithoutConsumerAckIsNotMarkedProcessedOnCancel(t *testing.T) {
+	t.Parallel()
+
 	produced := make(chan struct{})
 	stateHandler := &fakeFileStateHandler{
 		files: []file_state_handler.FileState{{Pathname: "pending-ack.log"}},
@@ -568,7 +584,7 @@ func TestProducedRuleItemWithoutConsumerAckIsNotMarkedProcessedOnCancel(t *testi
 		listenChan:             make(chan string, 1),
 		ruleItemChan:           make(chan ruleItemEnvelope, 1),
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
 		ListenDirs: []string{t.TempDir()},
@@ -610,6 +626,8 @@ func TestProducedRuleItemWithoutConsumerAckIsNotMarkedProcessedOnCancel(t *testi
 }
 
 func TestProducedRuleItemIsMarkedProcessedOnlyAfterConsumerAck(t *testing.T) {
+	t.Parallel()
+
 	stateHandler := &fakeFileStateHandler{
 		files:       []file_state_handler.FileState{{Pathname: "acked.log"}},
 		fileHandler: &itemProducingFileHandler{},
@@ -619,7 +637,7 @@ func TestProducedRuleItemIsMarkedProcessedOnlyAfterConsumerAck(t *testing.T) {
 		listenChan:             make(chan string, 1),
 		ruleItemChan:           make(chan ruleItemEnvelope, 1),
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	handler.sendFilesToBeProcessed(ctx, &config.DefaultModConfConfig{
 		ListenDirs: []string{t.TempDir()},

--- a/internal/mod/rule/handler_test.go
+++ b/internal/mod/rule/handler_test.go
@@ -31,7 +31,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var errTestReadFailed = errors.New("read failed")
+var (
+	errTestReadFailed           = errors.New("read failed")
+	errTestCancellationSentinel = errors.New("handler lost cancellation cause")
+	errTestConsumeFailed        = errors.New("consume failed")
+	errTestFirstItemFailed      = errors.New("first item failed")
+)
 
 func TestHandleCollectInfoTimeWindowLifecycle(t *testing.T) {
 	t.Parallel()
@@ -523,12 +528,11 @@ func TestCancellationDoesNotMarkFailedWhenHandlerReturnsSentinelError(t *testing
 	t.Parallel()
 
 	started := make(chan struct{}, 1)
-	sentinelErr := errors.New("handler lost cancellation cause")
 	stateHandler := &fakeFileStateHandler{
 		files: []file_state_handler.FileState{{Pathname: "cancelled-sentinel.log"}},
 		fileHandler: &cancellationBlockingHandler{
 			started: started,
-			err:     sentinelErr,
+			err:     errTestCancellationSentinel,
 		},
 	}
 	handler := &CustomRuleHandler{
@@ -557,7 +561,7 @@ func TestCancellationDoesNotMarkFailedWhenHandlerReturnsSentinelError(t *testing
 	}, time.Second, 10*time.Millisecond)
 
 	cancel()
-	require.False(t, shouldMarkFileFailed(ctx, sentinelErr))
+	require.False(t, shouldMarkFileFailed(ctx, errTestCancellationSentinel))
 	require.Eventually(t, func() bool {
 		select {
 		case <-done:
@@ -793,12 +797,11 @@ func TestProducedRuleItemIsMarkedProcessedOnlyAfterConsumerAck(t *testing.T) {
 func TestRuleItemConsumptionErrorMarksFileFailed(t *testing.T) {
 	t.Parallel()
 
-	consumeErr := errors.New("consume failed")
 	action, err := rule_engine.NewAction(
 		"failing-action",
 		map[string]interface{}{},
 		func(map[string]interface{}) error {
-			return consumeErr
+			return errTestConsumeFailed
 		},
 	)
 	require.NoError(t, err)
@@ -892,16 +895,15 @@ func TestRuleItemConsumptionErrorDrainsRemainingHandlerItems(t *testing.T) {
 
 	var consumedIndexes []int
 	consumerDone := make(chan struct{})
-	firstConsumeErr := errors.New("first item failed")
 	go func() {
 		defer close(consumerDone)
-		for index := 0; index < 2; index++ {
+		for index := range 2 {
 			select {
 			case envelope := <-handler.ruleMessageChan:
 				itemIndex, _ := envelope.item.Msg["index"].(int)
 				consumedIndexes = append(consumedIndexes, itemIndex)
 				if index == 0 {
-					envelope.result <- firstConsumeErr
+					envelope.result <- errTestFirstItemFailed
 				} else {
 					envelope.result <- nil
 				}

--- a/pkg/mcap_ros2/cdr_reader.go
+++ b/pkg/mcap_ros2/cdr_reader.go
@@ -22,6 +22,20 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// maxDecodedArrayBytes caps the estimated backing storage of any decoded
+	// array. It is deliberately independent of the encoded payload size because
+	// []string and []interface{} amplify small encoded elements into two-word Go
+	// values.
+	maxDecodedArrayBytes = 64 << 20
+
+	// Interfaces and strings both occupy two machine words on the supported
+	// 64-bit targets. Keeping the conservative 16-byte estimate on 32-bit
+	// targets only makes the decoder limit stricter.
+	resultInterfaceSlotBytes = 16
+	resultStringHeaderBytes  = 16
+)
+
 // CdrReader parses values from CDR data.
 type CdrReader struct {
 	data         []byte
@@ -50,6 +64,14 @@ func (r *CdrReader) DecodedBytes() int {
 // ByteLength returns the number of bytes in the CDR data.
 func (r *CdrReader) ByteLength() int {
 	return len(r.data)
+}
+
+// RemainingBytes returns the number of unread bytes in the CDR payload.
+func (r *CdrReader) RemainingBytes() int {
+	if r.offset >= len(r.data) {
+		return 0
+	}
+	return len(r.data) - r.offset
 }
 
 // Boolean reads an 8-bit value and interprets it as a boolean.
@@ -143,17 +165,19 @@ func (r *CdrReader) String() (string, error) {
 		return "", err
 	}
 
-	if length <= 1 {
-		r.offset += int(length)
-		return "", nil
+	if uint64(length) > uint64(maxInt()) {
+		return "", errors.Errorf("string declared length %d cannot fit in int", length)
 	}
 
-	str, err := r.StringRaw(int(length - 1))
+	data, err := r.Uint8Array(int(length))
 	if err != nil {
 		return "", err
 	}
-	r.offset++ // Skip null terminator
-	return str, nil
+	if length <= 1 {
+		return "", nil
+	}
+
+	return string(data[:len(data)-1]), nil
 }
 
 // StringRaw reads a string of the given length.
@@ -188,8 +212,8 @@ func (r *CdrReader) align(size int) {
 
 // read reads bytes from the current offset and advances the offset.
 func (r *CdrReader) read(size int) ([]byte, error) {
-	if r.offset+size > len(r.data) {
-		return nil, errors.Errorf("attempt to read past end of data (offset: %d, size: %d, data length: %d)", r.offset, size, len(r.data))
+	if size < 0 {
+		return nil, errors.Errorf("attempt to read a negative size %d", size)
 	}
 
 	// Align before reading if size > 1
@@ -197,13 +221,77 @@ func (r *CdrReader) read(size int) ([]byte, error) {
 		r.align(size)
 	}
 
+	if r.offset > len(r.data) || size > len(r.data)-r.offset {
+		return nil, errors.Errorf("attempt to read past end of data (offset: %d, size: %d, data length: %d)", r.offset, size, len(r.data))
+	}
+
 	data := r.data[r.offset : r.offset+size]
 	r.offset += size
 	return data, nil
 }
 
+func maxInt() int {
+	return int(^uint(0) >> 1)
+}
+
+// validateArrayLength validates a declared array length before it is converted
+// to int or used by make/slicing.
+func validateArrayLength(length uint64, remainingBytes, minEncodedBytes, resultElementBytes int) error {
+	if remainingBytes < 0 || minEncodedBytes <= 0 || resultElementBytes <= 0 {
+		return errors.Errorf(
+			"invalid array validation parameters (remaining=%d, minimum encoded element=%d, result element=%d)",
+			remainingBytes,
+			minEncodedBytes,
+			resultElementBytes,
+		)
+	}
+
+	remainingLimit := uint64(remainingBytes / minEncodedBytes)
+	if length > remainingLimit {
+		return errors.Errorf(
+			"array declared length %d exceeds remaining-data limit %d (remaining=%d bytes, minimum encoded element=%d bytes)",
+			length,
+			remainingLimit,
+			remainingBytes,
+			minEncodedBytes,
+		)
+	}
+
+	allocationLimit := uint64(maxDecodedArrayBytes / resultElementBytes)
+	if length > allocationLimit {
+		return errors.Errorf(
+			"array declared length %d exceeds decoder allocation limit %d elements (%d bytes, result element=%d bytes)",
+			length,
+			allocationLimit,
+			maxDecodedArrayBytes,
+			resultElementBytes,
+		)
+	}
+
+	if length > uint64(maxInt()) {
+		return errors.Errorf("array declared length %d cannot fit in int", length)
+	}
+
+	return nil
+}
+
+func (r *CdrReader) validateArrayLength(length, minEncodedBytes, resultElementBytes int) error {
+	if length < 0 {
+		return errors.Errorf("array declared a negative length %d", length)
+	}
+	return validateArrayLength(
+		uint64(length),
+		r.RemainingBytes(),
+		minEncodedBytes,
+		resultElementBytes,
+	)
+}
+
 // BooleanArray reads an array of booleans.
 func (r *CdrReader) BooleanArray(length int) ([]bool, error) {
+	if err := r.validateArrayLength(length, 1, 1); err != nil {
+		return nil, err
+	}
 	result := make([]bool, length)
 	for i := range length {
 		val, err := r.Boolean()
@@ -217,6 +305,9 @@ func (r *CdrReader) BooleanArray(length int) ([]bool, error) {
 
 // Uint8Array reads an array of uint8 values.
 func (r *CdrReader) Uint8Array(length int) ([]uint8, error) {
+	if err := r.validateArrayLength(length, 1, 1); err != nil {
+		return nil, err
+	}
 	data := r.data[r.offset : r.offset+length]
 	r.offset += length
 	return data, nil
@@ -224,6 +315,9 @@ func (r *CdrReader) Uint8Array(length int) ([]uint8, error) {
 
 // Int8Array reads an array of int8 values.
 func (r *CdrReader) Int8Array(length int) ([]int8, error) {
+	if err := r.validateArrayLength(length, 1, 1); err != nil {
+		return nil, err
+	}
 	result := make([]int8, length)
 	for i := range length {
 		val, err := r.Int8()
@@ -237,6 +331,9 @@ func (r *CdrReader) Int8Array(length int) ([]int8, error) {
 
 // Int16Array reads an array of int16 values.
 func (r *CdrReader) Int16Array(length int) ([]int16, error) {
+	if err := r.validateArrayLength(length, 2, 2); err != nil {
+		return nil, err
+	}
 	result := make([]int16, length)
 	for i := range length {
 		val, err := r.Int16()
@@ -250,6 +347,9 @@ func (r *CdrReader) Int16Array(length int) ([]int16, error) {
 
 // Uint16Array reads an array of uint16 values.
 func (r *CdrReader) Uint16Array(length int) ([]uint16, error) {
+	if err := r.validateArrayLength(length, 2, 2); err != nil {
+		return nil, err
+	}
 	result := make([]uint16, length)
 	for i := range length {
 		val, err := r.Uint16()
@@ -263,6 +363,9 @@ func (r *CdrReader) Uint16Array(length int) ([]uint16, error) {
 
 // Int32Array reads an array of int32 values.
 func (r *CdrReader) Int32Array(length int) ([]int32, error) {
+	if err := r.validateArrayLength(length, 4, 4); err != nil {
+		return nil, err
+	}
 	result := make([]int32, length)
 	for i := range length {
 		val, err := r.Int32()
@@ -276,6 +379,9 @@ func (r *CdrReader) Int32Array(length int) ([]int32, error) {
 
 // Uint32Array reads an array of uint32 values.
 func (r *CdrReader) Uint32Array(length int) ([]uint32, error) {
+	if err := r.validateArrayLength(length, 4, 4); err != nil {
+		return nil, err
+	}
 	result := make([]uint32, length)
 	for i := range length {
 		val, err := r.Uint32()
@@ -289,6 +395,9 @@ func (r *CdrReader) Uint32Array(length int) ([]uint32, error) {
 
 // Int64Array reads an array of int64 values.
 func (r *CdrReader) Int64Array(length int) ([]int64, error) {
+	if err := r.validateArrayLength(length, 8, 8); err != nil {
+		return nil, err
+	}
 	result := make([]int64, length)
 	for i := range length {
 		val, err := r.Int64()
@@ -302,6 +411,9 @@ func (r *CdrReader) Int64Array(length int) ([]int64, error) {
 
 // Uint64Array reads an array of uint64 values.
 func (r *CdrReader) Uint64Array(length int) ([]uint64, error) {
+	if err := r.validateArrayLength(length, 8, 8); err != nil {
+		return nil, err
+	}
 	result := make([]uint64, length)
 	for i := range length {
 		val, err := r.Uint64()
@@ -315,6 +427,9 @@ func (r *CdrReader) Uint64Array(length int) ([]uint64, error) {
 
 // Float32Array reads an array of float32 values.
 func (r *CdrReader) Float32Array(length int) ([]JSONFloat32, error) {
+	if err := r.validateArrayLength(length, 4, 4); err != nil {
+		return nil, err
+	}
 	result := make([]JSONFloat32, length)
 	for i := range length {
 		val, err := r.Float32()
@@ -328,6 +443,9 @@ func (r *CdrReader) Float32Array(length int) ([]JSONFloat32, error) {
 
 // Float64Array reads an array of float64 values.
 func (r *CdrReader) Float64Array(length int) ([]JSONFloat64, error) {
+	if err := r.validateArrayLength(length, 8, 8); err != nil {
+		return nil, err
+	}
 	result := make([]JSONFloat64, length)
 	for i := range length {
 		val, err := r.Float64()
@@ -341,6 +459,9 @@ func (r *CdrReader) Float64Array(length int) ([]JSONFloat64, error) {
 
 // StringArray reads an array of strings.
 func (r *CdrReader) StringArray(length int) ([]string, error) {
+	if err := r.validateArrayLength(length, 4, resultStringHeaderBytes); err != nil {
+		return nil, err
+	}
 	result := make([]string, length)
 	for i := range length {
 		val, err := r.String()

--- a/pkg/mcap_ros2/cdr_reader.go
+++ b/pkg/mcap_ros2/cdr_reader.go
@@ -34,6 +34,11 @@ const (
 	// targets only makes the decoder limit stricter.
 	resultInterfaceSlotBytes = 16
 	resultStringHeaderBytes  = 16
+
+	// A decoded complex element owns both its interface slot and at least one
+	// map produced by readComplexType. Budget conservatively for that object
+	// graph rather than only for the interface backing array.
+	resultComplexElementBytes = 128
 )
 
 // CdrReader parses values from CDR data.
@@ -83,13 +88,19 @@ func (r *CdrReader) Boolean() (bool, error) {
 // Int8 reads a signed 8-bit integer.
 func (r *CdrReader) Int8() (int8, error) {
 	val, err := r.read(1)
-	return int8(val[0]), err
+	if err != nil {
+		return 0, err
+	}
+	return int8(val[0]), nil
 }
 
 // Uint8 reads an unsigned 8-bit integer.
 func (r *CdrReader) Uint8() (uint8, error) {
 	val, err := r.read(1)
-	return val[0], err
+	if err != nil {
+		return 0, err
+	}
+	return val[0], nil
 }
 
 // uint16ToInt16 converts a uint16 to a int16.
@@ -101,13 +112,19 @@ func uint16ToInt16(u uint16) int16 {
 // Int16 reads a signed 16-bit integer.
 func (r *CdrReader) Int16() (int16, error) {
 	val, err := r.read(2)
-	return uint16ToInt16(r.byteOrder().Uint16(val)), err
+	if err != nil {
+		return 0, err
+	}
+	return uint16ToInt16(r.byteOrder().Uint16(val)), nil
 }
 
 // Uint16 reads an unsigned 16-bit integer.
 func (r *CdrReader) Uint16() (uint16, error) {
 	val, err := r.read(2)
-	return r.byteOrder().Uint16(val), err
+	if err != nil {
+		return 0, err
+	}
+	return r.byteOrder().Uint16(val), nil
 }
 
 // uint32ToInt32 converts a uint32 to a int32.
@@ -119,13 +136,19 @@ func uint32ToInt32(u uint32) int32 {
 // Int32 reads a signed 32-bit integer.
 func (r *CdrReader) Int32() (int32, error) {
 	val, err := r.read(4)
-	return uint32ToInt32(r.byteOrder().Uint32(val)), err
+	if err != nil {
+		return 0, err
+	}
+	return uint32ToInt32(r.byteOrder().Uint32(val)), nil
 }
 
 // Uint32 reads an unsigned 32-bit integer.
 func (r *CdrReader) Uint32() (uint32, error) {
 	val, err := r.read(4)
-	return r.byteOrder().Uint32(val), err
+	if err != nil {
+		return 0, err
+	}
+	return r.byteOrder().Uint32(val), nil
 }
 
 // uint64ToInt64 converts a uint64 to a int64.
@@ -137,25 +160,37 @@ func uint64ToInt64(u uint64) int64 {
 // Int64 reads a signed 64-bit integer.
 func (r *CdrReader) Int64() (int64, error) {
 	val, err := r.read(8)
-	return uint64ToInt64(r.byteOrder().Uint64(val)), err
+	if err != nil {
+		return 0, err
+	}
+	return uint64ToInt64(r.byteOrder().Uint64(val)), nil
 }
 
 // Uint64 reads an unsigned 64-bit integer.
 func (r *CdrReader) Uint64() (uint64, error) {
 	val, err := r.read(8)
-	return r.byteOrder().Uint64(val), err
+	if err != nil {
+		return 0, err
+	}
+	return r.byteOrder().Uint64(val), nil
 }
 
 // Float32 reads a 32-bit floating point number.
 func (r *CdrReader) Float32() (JSONFloat32, error) {
 	val, err := r.read(4)
-	return JSONFloat32(math.Float32frombits(r.byteOrder().Uint32(val))), err
+	if err != nil {
+		return 0, err
+	}
+	return JSONFloat32(math.Float32frombits(r.byteOrder().Uint32(val))), nil
 }
 
 // Float64 reads a 64-bit floating point number.
 func (r *CdrReader) Float64() (JSONFloat64, error) {
 	val, err := r.read(8)
-	return JSONFloat64(math.Float64frombits(r.byteOrder().Uint64(val))), err
+	if err != nil {
+		return 0, err
+	}
+	return JSONFloat64(math.Float64frombits(r.byteOrder().Uint64(val))), nil
 }
 
 // String reads a string prefixed with its 32-bit length.

--- a/pkg/mcap_ros2/cdr_reader.go
+++ b/pkg/mcap_ros2/cdr_reader.go
@@ -200,10 +200,12 @@ func (r *CdrReader) String() (string, error) {
 		return "", err
 	}
 
-	if uint64(length) > uint64(maxInt()) {
+	if uint64(length) > uint64(math.MaxInt) {
 		return "", errors.Errorf("string declared length %d cannot fit in int", length)
 	}
 
+	// The conversion is safe because the platform int bound is checked above.
+	// #nosec G115
 	data, err := r.Uint8Array(int(length))
 	if err != nil {
 		return "", err
@@ -265,13 +267,31 @@ func (r *CdrReader) read(size int) ([]byte, error) {
 	return data, nil
 }
 
-func maxInt() int {
-	return int(^uint(0) >> 1)
-}
-
 // validateArrayLength validates a declared array length before it is converted
 // to int or used by make/slicing.
-func validateArrayLength(length uint64, remainingBytes, minEncodedBytes, resultElementBytes int) error {
+func validateArrayLength(
+	length uint64,
+	remainingBytes, minEncodedBytes, resultElementBytes int,
+) (int, error) {
+	if length > uint64(math.MaxInt) {
+		return 0, errors.Errorf("array declared length %d cannot fit in int", length)
+	}
+
+	// The conversion is safe because the platform int bound is checked above.
+	// #nosec G115
+	intLength := int(length)
+	return intLength, validateIntArrayLength(
+		intLength,
+		remainingBytes,
+		minEncodedBytes,
+		resultElementBytes,
+	)
+}
+
+func validateIntArrayLength(length, remainingBytes, minEncodedBytes, resultElementBytes int) error {
+	if length < 0 {
+		return errors.Errorf("array declared a negative length %d", length)
+	}
 	if remainingBytes < 0 || minEncodedBytes <= 0 || resultElementBytes <= 0 {
 		return errors.Errorf(
 			"invalid array validation parameters (remaining=%d, minimum encoded element=%d, result element=%d)",
@@ -281,7 +301,7 @@ func validateArrayLength(length uint64, remainingBytes, minEncodedBytes, resultE
 		)
 	}
 
-	remainingLimit := uint64(remainingBytes / minEncodedBytes)
+	remainingLimit := remainingBytes / minEncodedBytes
 	if length > remainingLimit {
 		return errors.Errorf(
 			"array declared length %d exceeds remaining-data limit %d (remaining=%d bytes, minimum encoded element=%d bytes)",
@@ -292,7 +312,7 @@ func validateArrayLength(length uint64, remainingBytes, minEncodedBytes, resultE
 		)
 	}
 
-	allocationLimit := uint64(maxDecodedArrayBytes / resultElementBytes)
+	allocationLimit := maxDecodedArrayBytes / resultElementBytes
 	if length > allocationLimit {
 		return errors.Errorf(
 			"array declared length %d exceeds decoder allocation limit %d elements (%d bytes, result element=%d bytes)",
@@ -303,23 +323,11 @@ func validateArrayLength(length uint64, remainingBytes, minEncodedBytes, resultE
 		)
 	}
 
-	if length > uint64(maxInt()) {
-		return errors.Errorf("array declared length %d cannot fit in int", length)
-	}
-
 	return nil
 }
 
 func (r *CdrReader) validateArrayLength(length, minEncodedBytes, resultElementBytes int) error {
-	if length < 0 {
-		return errors.Errorf("array declared a negative length %d", length)
-	}
-	return validateArrayLength(
-		uint64(length),
-		r.RemainingBytes(),
-		minEncodedBytes,
-		resultElementBytes,
-	)
+	return validateIntArrayLength(length, r.RemainingBytes(), minEncodedBytes, resultElementBytes)
 }
 
 // BooleanArray reads an array of booleans.

--- a/pkg/mcap_ros2/message_reader.go
+++ b/pkg/mcap_ros2/message_reader.go
@@ -404,17 +404,18 @@ func readField(
 	if err != nil {
 		return nil, err
 	}
-	if err := validateArrayLength(
+	length, err := validateArrayLength(
 		arrayLength,
 		reader.RemainingBytes(),
 		1,
 		resultComplexElementBytes,
-	); err != nil {
+	)
+	if err != nil {
 		return nil, err
 	}
 
-	array := make([]interface{}, int(arrayLength))
-	for i := range int(arrayLength) {
+	array := make([]interface{}, length)
+	for i := range length {
 		value, err := readComplexType(nestedDef, msgDefs, reader)
 		if err != nil {
 			return nil, err
@@ -434,15 +435,15 @@ func readPrimitiveArray(ftype Type, reader *CdrReader) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := validateArrayLength(
+	length, err := validateArrayLength(
 		arrayLength,
 		reader.RemainingBytes(),
 		minEncodedBytes,
 		resultElementBytes,
-	); err != nil {
+	)
+	if err != nil {
 		return nil, err
 	}
-	length := int(arrayLength)
 
 	switch ftype.Type {
 	case typeBool:

--- a/pkg/mcap_ros2/message_reader.go
+++ b/pkg/mcap_ros2/message_reader.go
@@ -400,26 +400,21 @@ func readField(
 		return readComplexType(nestedDef, msgDefs, reader)
 	}
 
-	var arrayLength int
-	if ftype.ArraySize != nil {
-		// Fixed size array
-		arrayLength = *ftype.ArraySize
-	} else {
-		// Dynamic array - read length prefix
-		length, err := reader.Uint32()
-		if err != nil {
-			return nil, err
-		}
-		arrayLength = int(length)
-
-		// Handle upper bound if specified
-		if ftype.IsUpperBound && ftype.ArraySize != nil && arrayLength > *ftype.ArraySize {
-			arrayLength = *ftype.ArraySize
-		}
+	arrayLength, err := readArrayLength(ftype, reader)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateArrayLength(
+		arrayLength,
+		reader.RemainingBytes(),
+		1,
+		resultInterfaceSlotBytes,
+	); err != nil {
+		return nil, err
 	}
 
-	array := make([]interface{}, arrayLength)
-	for i := range arrayLength {
+	array := make([]interface{}, int(arrayLength))
+	for i := range int(arrayLength) {
 		value, err := readComplexType(nestedDef, msgDefs, reader)
 		if err != nil {
 			return nil, err
@@ -431,51 +426,95 @@ func readField(
 
 // readPrimitiveArray reads an array of primitive values.
 func readPrimitiveArray(ftype Type, reader *CdrReader) (interface{}, error) {
-	var arrayLength int
-	if ftype.ArraySize != nil {
-		// Fixed size array
-		arrayLength = *ftype.ArraySize
-	} else {
-		// Dynamic array - read length prefix
-		length, err := reader.Uint32()
-		if err != nil {
-			return nil, err
-		}
-		arrayLength = int(length)
-
-		// Handle upper bound if specified
-		if ftype.IsUpperBound && ftype.ArraySize != nil && arrayLength > *ftype.ArraySize {
-			arrayLength = *ftype.ArraySize
-		}
+	arrayLength, err := readArrayLength(ftype, reader)
+	if err != nil {
+		return nil, err
 	}
+	minEncodedBytes, resultElementBytes, err := primitiveArrayElementSizes(ftype.Type)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateArrayLength(
+		arrayLength,
+		reader.RemainingBytes(),
+		minEncodedBytes,
+		resultElementBytes,
+	); err != nil {
+		return nil, err
+	}
+	length := int(arrayLength)
 
 	switch ftype.Type {
 	case typeBool:
-		return reader.BooleanArray(arrayLength)
+		return reader.BooleanArray(length)
 	case typeByte, typeUint8:
-		return reader.Uint8Array(arrayLength)
+		return reader.Uint8Array(length)
 	case typeChar, typeInt8:
-		return reader.Int8Array(arrayLength)
+		return reader.Int8Array(length)
 	case typeInt16:
-		return reader.Int16Array(arrayLength)
+		return reader.Int16Array(length)
 	case typeUint16:
-		return reader.Uint16Array(arrayLength)
+		return reader.Uint16Array(length)
 	case typeInt32:
-		return reader.Int32Array(arrayLength)
+		return reader.Int32Array(length)
 	case typeUint32:
-		return reader.Uint32Array(arrayLength)
+		return reader.Uint32Array(length)
 	case typeInt64:
-		return reader.Int64Array(arrayLength)
+		return reader.Int64Array(length)
 	case typeUint64:
-		return reader.Uint64Array(arrayLength)
+		return reader.Uint64Array(length)
 	case typeFloat32:
-		return reader.Float32Array(arrayLength)
+		return reader.Float32Array(length)
 	case typeFloat64:
-		return reader.Float64Array(arrayLength)
+		return reader.Float64Array(length)
 	case typeString:
-		return reader.StringArray(arrayLength)
+		return reader.StringArray(length)
 	default:
 		return nil, errors.Errorf("unsupported array type: %s", ftype.Type)
+	}
+}
+
+func readArrayLength(ftype Type, reader *CdrReader) (uint64, error) {
+	if ftype.ArraySize != nil && !ftype.IsUpperBound {
+		if *ftype.ArraySize < 0 {
+			return 0, errors.Errorf("array declared a negative fixed length %d", *ftype.ArraySize)
+		}
+		return uint64(*ftype.ArraySize), nil
+	}
+
+	length, err := reader.SequenceLength()
+	if err != nil {
+		return 0, err
+	}
+	if ftype.IsUpperBound && ftype.ArraySize != nil {
+		if *ftype.ArraySize < 0 {
+			return 0, errors.Errorf("array declared a negative schema upper bound %d", *ftype.ArraySize)
+		}
+		if uint64(length) > uint64(*ftype.ArraySize) {
+			return 0, errors.Errorf(
+				"array declared length %d exceeds schema upper bound %d",
+				length,
+				*ftype.ArraySize,
+			)
+		}
+	}
+	return uint64(length), nil
+}
+
+func primitiveArrayElementSizes(typeName string) (int, int, error) {
+	switch typeName {
+	case typeBool, typeByte, typeUint8, typeChar, typeInt8:
+		return 1, 1, nil
+	case typeInt16, typeUint16:
+		return 2, 2, nil
+	case typeInt32, typeUint32, typeFloat32:
+		return 4, 4, nil
+	case typeInt64, typeUint64, typeFloat64:
+		return 8, 8, nil
+	case typeString:
+		return 4, resultStringHeaderBytes, nil
+	default:
+		return 0, 0, errors.Errorf("unsupported array type: %s", typeName)
 	}
 }
 

--- a/pkg/mcap_ros2/message_reader.go
+++ b/pkg/mcap_ros2/message_reader.go
@@ -408,7 +408,7 @@ func readField(
 		arrayLength,
 		reader.RemainingBytes(),
 		1,
-		resultInterfaceSlotBytes,
+		resultComplexElementBytes,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/mcap_ros2/message_reader_test.go
+++ b/pkg/mcap_ros2/message_reader_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcap_ros2
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dynamicArrayData(length uint32, payload ...byte) []byte {
+	data := make([]byte, 8, 8+len(payload))
+	data[1] = 1 // Little-endian CDR.
+	binary.LittleEndian.PutUint32(data[4:], length)
+	return append(data, payload...)
+}
+
+func TestReadPrimitiveArrayRejectsLengthExceedingRemainingData(t *testing.T) {
+	reader, err := NewCdrReader(dynamicArrayData(math.MaxUint32))
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err = readPrimitiveArray(Type{Type: typeUint8, IsArray: true}, reader)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declared length")
+	assert.Contains(t, err.Error(), "remaining")
+}
+
+func TestReadComplexArrayRejectsLengthExceedingRemainingData(t *testing.T) {
+	reader, err := NewCdrReader(dynamicArrayData(math.MaxUint32))
+	require.NoError(t, err)
+	field := Field{
+		Type: Type{
+			PkgName: "test",
+			Type:    "Empty",
+			IsArray: true,
+		},
+		Name: "items",
+	}
+	msgDefs := map[string]MessageSpecification{
+		"test/Empty": {PkgName: "test", MsgName: "Empty"},
+	}
+
+	require.NotPanics(t, func() {
+		_, err = readField(field, msgDefs, reader)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declared length")
+	assert.Contains(t, err.Error(), "remaining")
+}
+
+func TestValidateArrayLengthRejectsHardAllocationLimit(t *testing.T) {
+	length := uint64(maxDecodedArrayBytes/resultInterfaceSlotBytes + 1)
+
+	err := validateArrayLength(length, math.MaxInt, 1, resultInterfaceSlotBytes)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoder allocation limit")
+}
+
+func TestReadPrimitiveArrayDecodesValidDynamicArray(t *testing.T) {
+	reader, err := NewCdrReader(dynamicArrayData(3, 1, 2, 3))
+	require.NoError(t, err)
+
+	value, err := readPrimitiveArray(Type{Type: typeUint8, IsArray: true}, reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []uint8{1, 2, 3}, value)
+}
+
+func TestReadComplexArrayDecodesValidDynamicArray(t *testing.T) {
+	reader, err := NewCdrReader(dynamicArrayData(2, 7, 8))
+	require.NoError(t, err)
+	field := Field{
+		Type: Type{
+			PkgName: "test",
+			Type:    "Empty",
+			IsArray: true,
+		},
+		Name: "items",
+	}
+	msgDefs := map[string]MessageSpecification{
+		"test/Empty": {PkgName: "test", MsgName: "Empty"},
+	}
+
+	value, err := readField(field, msgDefs, reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{
+		map[string]interface{}{},
+		map[string]interface{}{},
+	}, value)
+}
+
+func TestReadPrimitiveArrayDecodesBoundedDynamicArray(t *testing.T) {
+	bound := 3
+	reader, err := NewCdrReader(dynamicArrayData(2, 7, 8))
+	require.NoError(t, err)
+
+	value, err := readPrimitiveArray(Type{
+		Type:         typeUint8,
+		IsArray:      true,
+		ArraySize:    &bound,
+		IsUpperBound: true,
+	}, reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []uint8{7, 8}, value)
+}
+
+func TestReadPrimitiveArrayRejectsSchemaBoundViolation(t *testing.T) {
+	bound := 3
+	reader, err := NewCdrReader(dynamicArrayData(4, 1, 2, 3, 4))
+	require.NoError(t, err)
+
+	_, err = readPrimitiveArray(Type{
+		Type:         typeUint8,
+		IsArray:      true,
+		ArraySize:    &bound,
+		IsUpperBound: true,
+	}, reader)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schema upper bound")
+}
+
+func TestReadPrimitiveFixedArrayRejectsTruncatedDataWithoutPanic(t *testing.T) {
+	arraySize := 3
+	reader, err := NewCdrReader([]byte{0, 1, 0, 0, 1})
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err = readPrimitiveArray(Type{
+			Type:      typeUint8,
+			IsArray:   true,
+			ArraySize: &arraySize,
+		}, reader)
+	})
+	require.Error(t, err)
+}

--- a/pkg/mcap_ros2/message_reader_test.go
+++ b/pkg/mcap_ros2/message_reader_test.go
@@ -31,6 +31,8 @@ func dynamicArrayData(length uint32, payload ...byte) []byte {
 }
 
 func TestReadPrimitiveArrayRejectsLengthExceedingRemainingData(t *testing.T) {
+	t.Parallel()
+
 	reader, err := NewCdrReader(dynamicArrayData(math.MaxUint32))
 	require.NoError(t, err)
 
@@ -43,6 +45,8 @@ func TestReadPrimitiveArrayRejectsLengthExceedingRemainingData(t *testing.T) {
 }
 
 func TestReadComplexArrayRejectsLengthExceedingRemainingData(t *testing.T) {
+	t.Parallel()
+
 	reader, err := NewCdrReader(dynamicArrayData(math.MaxUint32))
 	require.NoError(t, err)
 	field := Field{
@@ -66,6 +70,8 @@ func TestReadComplexArrayRejectsLengthExceedingRemainingData(t *testing.T) {
 }
 
 func TestReadComplexArrayRejectsHardAllocationLimit(t *testing.T) {
+	t.Parallel()
+
 	length := maxDecodedArrayBytes/resultComplexElementBytes + 1
 	reader, err := NewCdrReader(dynamicArrayData(uint32(length), make([]byte, length)...))
 	require.NoError(t, err)
@@ -88,15 +94,19 @@ func TestReadComplexArrayRejectsHardAllocationLimit(t *testing.T) {
 }
 
 func TestValidateArrayLengthRejectsHardAllocationLimit(t *testing.T) {
+	t.Parallel()
+
 	length := uint64(maxDecodedArrayBytes/resultInterfaceSlotBytes + 1)
 
-	err := validateArrayLength(length, math.MaxInt, 1, resultInterfaceSlotBytes)
+	_, err := validateArrayLength(length, math.MaxInt, 1, resultInterfaceSlotBytes)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decoder allocation limit")
 }
 
 func TestReadPrimitiveArrayDecodesValidDynamicArray(t *testing.T) {
+	t.Parallel()
+
 	reader, err := NewCdrReader(dynamicArrayData(3, 1, 2, 3))
 	require.NoError(t, err)
 
@@ -107,6 +117,8 @@ func TestReadPrimitiveArrayDecodesValidDynamicArray(t *testing.T) {
 }
 
 func TestReadComplexArrayDecodesValidDynamicArray(t *testing.T) {
+	t.Parallel()
+
 	reader, err := NewCdrReader(dynamicArrayData(2, 7, 8))
 	require.NoError(t, err)
 	field := Field{
@@ -131,6 +143,8 @@ func TestReadComplexArrayDecodesValidDynamicArray(t *testing.T) {
 }
 
 func TestReadPrimitiveArrayDecodesBoundedDynamicArray(t *testing.T) {
+	t.Parallel()
+
 	bound := 3
 	reader, err := NewCdrReader(dynamicArrayData(2, 7, 8))
 	require.NoError(t, err)
@@ -147,6 +161,8 @@ func TestReadPrimitiveArrayDecodesBoundedDynamicArray(t *testing.T) {
 }
 
 func TestReadPrimitiveArrayRejectsSchemaBoundViolation(t *testing.T) {
+	t.Parallel()
+
 	bound := 3
 	reader, err := NewCdrReader(dynamicArrayData(4, 1, 2, 3, 4))
 	require.NoError(t, err)
@@ -163,6 +179,8 @@ func TestReadPrimitiveArrayRejectsSchemaBoundViolation(t *testing.T) {
 }
 
 func TestReadPrimitiveFixedArrayRejectsTruncatedDataWithoutPanic(t *testing.T) {
+	t.Parallel()
+
 	arraySize := 3
 	reader, err := NewCdrReader([]byte{0, 1, 0, 0, 1})
 	require.NoError(t, err)
@@ -178,6 +196,8 @@ func TestReadPrimitiveFixedArrayRejectsTruncatedDataWithoutPanic(t *testing.T) {
 }
 
 func TestReadMessageRejectsTruncatedSequenceLengthWithoutPanic(t *testing.T) {
+	t.Parallel()
+
 	msgDefs := map[string]MessageSpecification{
 		"test/Message": {
 			PkgName: "test",
@@ -199,6 +219,8 @@ func TestReadMessageRejectsTruncatedSequenceLengthWithoutPanic(t *testing.T) {
 }
 
 func TestScalarReadersReturnErrorsForTruncatedData(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]func(*CdrReader) error{
 		"boolean": func(reader *CdrReader) error {
 			_, err := reader.Boolean()
@@ -248,6 +270,8 @@ func TestScalarReadersReturnErrorsForTruncatedData(t *testing.T) {
 
 	for name, read := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			reader, err := NewCdrReader([]byte{0, 1, 0, 0})
 			require.NoError(t, err)
 
@@ -260,6 +284,8 @@ func TestScalarReadersReturnErrorsForTruncatedData(t *testing.T) {
 }
 
 func TestAlignedScalarReadReturnsErrorWithoutPanic(t *testing.T) {
+	t.Parallel()
+
 	reader, err := NewCdrReader([]byte{0, 1, 0, 0, 1, 2})
 	require.NoError(t, err)
 	_, err = reader.Uint8()

--- a/pkg/mcap_ros2/message_reader_test.go
+++ b/pkg/mcap_ros2/message_reader_test.go
@@ -65,6 +65,28 @@ func TestReadComplexArrayRejectsLengthExceedingRemainingData(t *testing.T) {
 	assert.Contains(t, err.Error(), "remaining")
 }
 
+func TestReadComplexArrayRejectsHardAllocationLimit(t *testing.T) {
+	length := maxDecodedArrayBytes/resultComplexElementBytes + 1
+	reader, err := NewCdrReader(dynamicArrayData(uint32(length), make([]byte, length)...))
+	require.NoError(t, err)
+	field := Field{
+		Type: Type{
+			PkgName: "test",
+			Type:    "Empty",
+			IsArray: true,
+		},
+		Name: "items",
+	}
+	msgDefs := map[string]MessageSpecification{
+		"test/Empty": {PkgName: "test", MsgName: "Empty"},
+	}
+
+	_, err = readField(field, msgDefs, reader)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoder allocation limit")
+}
+
 func TestValidateArrayLengthRejectsHardAllocationLimit(t *testing.T) {
 	length := uint64(maxDecodedArrayBytes/resultInterfaceSlotBytes + 1)
 
@@ -153,4 +175,99 @@ func TestReadPrimitiveFixedArrayRejectsTruncatedDataWithoutPanic(t *testing.T) {
 		}, reader)
 	})
 	require.Error(t, err)
+}
+
+func TestReadMessageRejectsTruncatedSequenceLengthWithoutPanic(t *testing.T) {
+	msgDefs := map[string]MessageSpecification{
+		"test/Message": {
+			PkgName: "test",
+			MsgName: "Message",
+			Fields: []Field{{
+				Type: Type{Type: typeUint8, IsArray: true},
+				Name: "values",
+			}},
+		},
+	}
+	data := []byte{0, 1, 0, 0, 2, 0}
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = ReadMessage("test/Message", msgDefs, data)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "past end of data")
+}
+
+func TestScalarReadersReturnErrorsForTruncatedData(t *testing.T) {
+	tests := map[string]func(*CdrReader) error{
+		"boolean": func(reader *CdrReader) error {
+			_, err := reader.Boolean()
+			return err
+		},
+		"int8": func(reader *CdrReader) error {
+			_, err := reader.Int8()
+			return err
+		},
+		"uint8": func(reader *CdrReader) error {
+			_, err := reader.Uint8()
+			return err
+		},
+		"int16": func(reader *CdrReader) error {
+			_, err := reader.Int16()
+			return err
+		},
+		"uint16": func(reader *CdrReader) error {
+			_, err := reader.Uint16()
+			return err
+		},
+		"int32": func(reader *CdrReader) error {
+			_, err := reader.Int32()
+			return err
+		},
+		"uint32": func(reader *CdrReader) error {
+			_, err := reader.Uint32()
+			return err
+		},
+		"int64": func(reader *CdrReader) error {
+			_, err := reader.Int64()
+			return err
+		},
+		"uint64": func(reader *CdrReader) error {
+			_, err := reader.Uint64()
+			return err
+		},
+		"float32": func(reader *CdrReader) error {
+			_, err := reader.Float32()
+			return err
+		},
+		"float64": func(reader *CdrReader) error {
+			_, err := reader.Float64()
+			return err
+		},
+	}
+
+	for name, read := range tests {
+		t.Run(name, func(t *testing.T) {
+			reader, err := NewCdrReader([]byte{0, 1, 0, 0})
+			require.NoError(t, err)
+
+			require.NotPanics(t, func() {
+				err = read(reader)
+			})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestAlignedScalarReadReturnsErrorWithoutPanic(t *testing.T) {
+	reader, err := NewCdrReader([]byte{0, 1, 0, 0, 1, 2})
+	require.NoError(t, err)
+	_, err = reader.Uint8()
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err = reader.Uint32()
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "offset: 8")
 }


### PR DESCRIPTION
## Summary

Runtime faults now fail safely instead of crashing the daemon, losing queued rule work, accepting partial configuration, reporting false readiness, or allocating directly from untrusted CDR lengths.

The important behavior change is end-to-end completion tracking: a listened file is marked `processed` only after every emitted rule item has completed synchronous `ConsumeNext` handling. Cancellation leaves unfinished files retryable, while permanently malformed individual MCAP/ROS1 messages remain best-effort skips so healthy messages are not replayed forever.

## Safety guarantees

| Area | Guarantee |
| --- | --- |
| File state | State and directory sets use one `RWMutex`; persistence and traversal operate on lock-protected snapshots. |
| Rule workers | Channel sends, semaphore waits, and file handlers observe cancellation; in-flight files are deduplicated and completion is acknowledged by the consumer. |
| Configuration | Loaders return errors, runtime reloads preserve the last complete configuration, and unavailable imports cannot overwrite it with a partial merge. |
| Master startup | Readiness is reported only after `net.Listen` succeeds; bind failures propagate to the command lifecycle so a later authorized status can retry. |
| CDR decoding | Array lengths are limited by remaining payload and a 64 MiB decode budget, with conservative complex-object accounting and explicit schema-bound errors. |


## Compatibility notes

- A declared local __import__ file is now required at startup. Deployments that relied on an absent optional override must create it or remove the import before upgrading.
- A non-cancellation file or rule-consumption error moves the unchanged file to a terminal failed state. It becomes eligible again only after its size or nanosecond modification time changes; this prevents repeated, non-idempotent uploads.

## Validation

- `go test ./...`
- `go test -race ./cmd/coscout/commands ./internal/config ./internal/daemon ./internal/master ./internal/mod/rule/... ./pkg/mcap_ros2 -count=1`
- `go vet ./...`
- `git diff --check origin/main...HEAD`

## New concepts

### Last-known-good configuration

A last-known-good reload keeps serving the most recent complete configuration when a new candidate cannot be fully read or parsed.

```mermaid
flowchart LR
    A["Load candidate"] --> B{"All declared inputs valid?"}
    B -- "yes" --> C["Replace last-known-good"]
    B -- "no" --> D["Return error + existing last-known-good"]
```

This is used here because runtime configuration spans a base file plus local and remote imports. Accepting only the pieces that happen to be available would silently change collection, upload, or rule behavior.

The startup loader seeds an explicit local baseline; only a complete runtime merge may replace it.

Do not use this pattern when stale configuration is more dangerous than downtime—for example, when a revoked security policy must take effect immediately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coScout/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787888055&installation_model_id=425002&pr_number=228&repository=coscene-io%2FcoScout&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoScout%2Fpull%2F228&signature=8b9b97ce78ec75ea6e80b16e1d8bc0707e09b84aa75e61d488d3175386940065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->