### PR TITLE
fix(master): surface slave errors and support long downloads

### DIFF
--- a/internal/collector/upload.go
+++ b/internal/collector/upload.go
@@ -1001,7 +1001,7 @@ func getSlaveFileCachePath(cacheFolder, recordName, slaveFilePath string) string
 
 // downloadSlaveFileToLocal downloads slave file to local cache.
 func downloadSlaveFileToLocal(parentCtx context.Context, fileManager *master.FileManager, fileInfo *model.FileInfo, localPath string, maxSize int64) error {
-	ctx, cancel := context.WithTimeout(parentCtx, 30*time.Minute)
+	ctx, cancel := context.WithTimeout(parentCtx, config.DefaultFileTransferTimeout)
 	defer cancel()
 
 	// Get file reader from FileManager (with optional size limit)

--- a/internal/config/master_slave.go
+++ b/internal/config/master_slave.go
@@ -18,6 +18,8 @@ import (
 	"time"
 )
 
+const DefaultFileTransferTimeout = 30 * time.Minute
+
 // SlaveConfig slave configuration.
 type SlaveConfig struct {
 	ID                string        `yaml:"id"`                 // Unique slave ID (auto-generated)

--- a/internal/master/client.go
+++ b/internal/master/client.go
@@ -37,15 +37,25 @@ var (
 
 // Client master to slave client.
 type Client struct {
-	httpClient *http.Client
-	config     *config.MasterConfig
+	httpClient     *http.Client
+	downloadClient *http.Client
+	config         *config.MasterConfig
 }
 
 // NewClient creates a new master client.
 func NewClient(masterConfig *config.MasterConfig) *Client {
+	downloadTransport := http.DefaultTransport.(*http.Transport).Clone()
+	downloadTransport.ResponseHeaderTimeout = masterConfig.RequestTimeout
+
 	return &Client{
 		httpClient: &http.Client{
 			Timeout: masterConfig.RequestTimeout,
+		},
+		// File downloads are bounded by their request context. Keeping the
+		// response-header timeout catches an unresponsive slave without applying
+		// RequestTimeout to the potentially long response-body transfer.
+		downloadClient: &http.Client{
+			Transport: downloadTransport,
 		},
 		config: masterConfig,
 	}
@@ -157,7 +167,7 @@ func (c *Client) DownloadSlaveFileWithSize(ctx context.Context, slave *SlaveInfo
 
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.downloadClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("send download request to slave %s: %w", slave.ID, err)
 	}
@@ -246,7 +256,7 @@ func (c *Client) RequestAllSlaveFiles(ctx context.Context, registry *SlaveRegist
 				}
 			} else {
 				results[res.slaveID] = res.resp
-				log.Infof("Successfully got %d files from slave %s", len(res.resp.Files), res.slaveID)
+				logSlaveTaskResponse(res.slaveID, req.TaskID, res.resp)
 			}
 		case <-ctx.Done():
 			log.Warn("Context cancelled while waiting for slave responses")
@@ -302,7 +312,7 @@ func (c *Client) RequestAllSlaveFilesByContent(ctx context.Context, registry *Sl
 				}
 			} else {
 				results[res.slaveID] = res.resp
-				log.Infof("Successfully got %d files from slave %s", len(res.resp.Files), res.slaveID)
+				logSlaveTaskResponse(res.slaveID, req.TaskID, res.resp)
 			}
 		case <-ctx.Done():
 			log.Warn("Context cancelled while waiting for slave responses")
@@ -311,4 +321,23 @@ func (c *Client) RequestAllSlaveFilesByContent(ctx context.Context, registry *Sl
 	}
 
 	return results
+}
+
+func logSlaveTaskResponse(slaveID, taskID string, response *TaskResponse) {
+	logger := log.WithFields(log.Fields{
+		"slaveID":  slaveID,
+		"taskName": taskID,
+	})
+	if response == nil {
+		logger.Error("Slave returned an empty scan response")
+		return
+	}
+	if !response.Success {
+		logger.WithFields(log.Fields{
+			"errorCode": response.ErrorCode,
+			"error":     response.Error,
+		}).Warn("Slave file scan failed; continuing with available results")
+		return
+	}
+	logger.WithField("files", len(response.Files)).Info("Successfully got files from slave")
 }

--- a/internal/master/client.go
+++ b/internal/master/client.go
@@ -44,7 +44,10 @@ type Client struct {
 
 // NewClient creates a new master client.
 func NewClient(masterConfig *config.MasterConfig) *Client {
-	downloadTransport := http.DefaultTransport.(*http.Transport).Clone()
+	downloadTransport := &http.Transport{Proxy: http.ProxyFromEnvironment}
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+		downloadTransport = defaultTransport.Clone()
+	}
 	downloadTransport.ResponseHeaderTimeout = masterConfig.RequestTimeout
 
 	return &Client{

--- a/internal/master/client_test.go
+++ b/internal/master/client_test.go
@@ -153,7 +153,11 @@ func TestDownloadSlaveFileBodyReadStopsWhenCallerContextIsCancelled(t *testing.T
 		if _, err := w.Write([]byte(firstChunk)); err != nil {
 			return
 		}
-		w.(http.Flusher).Flush()
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		flusher.Flush()
 		close(headersFlushed)
 		<-r.Context().Done()
 		close(requestCancelled)

--- a/internal/master/client_test.go
+++ b/internal/master/client_test.go
@@ -84,3 +84,127 @@ func TestDownloadSlaveFileAllowsBodyTransferBeyondRequestTimeout(t *testing.T) {
 		t.Fatalf("content = %q, want %q", got, want)
 	}
 }
+
+func TestDownloadSlaveFileFailsWhenResponseHeadersExceedRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	requestStarted := make(chan struct{})
+	releaseResponse := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-releaseResponse
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer func() {
+		close(releaseResponse)
+		server.Close()
+	}()
+
+	host, portRaw, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split server address: %v", err)
+	}
+	port, err := strconv.Atoi(portRaw)
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+
+	masterConfig := config.DefaultMasterConfig()
+	masterConfig.RequestTimeout = 25 * time.Millisecond
+	client := NewClient(masterConfig)
+	slave := &SlaveInfo{ID: "0011223344556677", IP: host, Port: port}
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		reader, err := client.DownloadSlaveFile(ctx, slave, "/tmp/source.bag")
+		if reader != nil {
+			_ = reader.Close()
+		}
+		result <- err
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive download request")
+	}
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("DownloadSlaveFile succeeded after response header timeout")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("DownloadSlaveFile did not time out waiting for response headers")
+	}
+}
+
+func TestDownloadSlaveFileBodyReadStopsWhenCallerContextIsCancelled(t *testing.T) {
+	t.Parallel()
+
+	const firstChunk = "first"
+	headersFlushed := make(chan struct{})
+	requestCancelled := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(firstChunk)); err != nil {
+			return
+		}
+		w.(http.Flusher).Flush()
+		close(headersFlushed)
+		<-r.Context().Done()
+		close(requestCancelled)
+	}))
+	defer server.Close()
+
+	host, portRaw, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split server address: %v", err)
+	}
+	port, err := strconv.Atoi(portRaw)
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+
+	masterConfig := config.DefaultMasterConfig()
+	masterConfig.RequestTimeout = 25 * time.Millisecond
+	client := NewClient(masterConfig)
+	slave := &SlaveInfo{ID: "0011223344556677", IP: host, Port: port}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	reader, err := client.DownloadSlaveFile(ctx, slave, "/tmp/source.bag")
+	if err != nil {
+		t.Fatalf("start download: %v", err)
+	}
+	defer reader.Close()
+
+	select {
+	case <-headersFlushed:
+	case <-time.After(time.Second):
+		t.Fatal("server did not flush response headers")
+	}
+
+	content := make([]byte, len(firstChunk))
+	if _, err := io.ReadFull(reader, content); err != nil {
+		t.Fatalf("read first response chunk: %v", err)
+	}
+	if got := string(content); got != firstChunk {
+		t.Fatalf("first response chunk = %q, want %q", got, firstChunk)
+	}
+
+	cancel()
+
+	if _, err := io.ReadAll(reader); err == nil {
+		t.Fatal("body read succeeded after caller context cancellation")
+	}
+	select {
+	case <-requestCancelled:
+	case <-time.After(time.Second):
+		t.Fatal("server did not observe caller context cancellation")
+	}
+}

--- a/internal/master/client_test.go
+++ b/internal/master/client_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package master
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/coscene-io/coscout/internal/config"
+)
+
+func TestDownloadSlaveFileAllowsBodyTransferBeyondRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	const (
+		firstChunk  = "first"
+		secondChunk = "second"
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/files/download" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(firstChunk)); err != nil {
+			return
+		}
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+
+		time.Sleep(75 * time.Millisecond)
+		_, _ = w.Write([]byte(secondChunk))
+	}))
+	defer server.Close()
+
+	host, portRaw, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split server address: %v", err)
+	}
+	port, err := strconv.Atoi(portRaw)
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+
+	masterConfig := config.DefaultMasterConfig()
+	masterConfig.RequestTimeout = 25 * time.Millisecond
+	client := NewClient(masterConfig)
+	slave := &SlaveInfo{ID: "0011223344556677", IP: host, Port: port}
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	reader, err := client.DownloadSlaveFile(ctx, slave, "/tmp/source.bag")
+	if err != nil {
+		t.Fatalf("start download: %v", err)
+	}
+	defer reader.Close()
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read download: %v", err)
+	}
+	if got, want := string(content), firstChunk+secondChunk; got != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+}

--- a/internal/master/types.go
+++ b/internal/master/types.go
@@ -212,6 +212,7 @@ type TaskResponse struct {
 const (
 	TaskErrorCodeInvalidTimeWindow  = "INVALID_TIME_WINDOW"
 	TaskErrorCodeTimeWindowNotReady = "TIME_WINDOW_NOT_READY"
+	TaskErrorCodeInternal           = "INTERNAL_ERROR"
 )
 
 // TaskResponsesTimeWindowErrorCode returns the strongest time-window status

--- a/internal/slave/server.go
+++ b/internal/slave/server.go
@@ -129,6 +129,10 @@ func (s *Server) handleFileScan(w http.ResponseWriter, r *http.Request) {
 		Success: err == nil,
 	}
 	if err != nil {
+		log.WithFields(log.Fields{
+			"taskName": req.TaskID,
+			"scanMode": "modification_time",
+		}).WithError(err).Error("Slave file scan failed")
 		resp.ErrorCode = scanErrorCode(err)
 		resp.Error = err.Error()
 	}
@@ -179,6 +183,14 @@ func (s *Server) handleFileDownload(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+	}
+
+	writeDeadline := time.Now().Add(config.DefaultFileTransferTimeout)
+	if err := http.NewResponseController(w).SetWriteDeadline(writeDeadline); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		log.WithFields(log.Fields{
+			"file":    realPath,
+			"timeout": config.DefaultFileTransferTimeout,
+		}).WithError(err).Warn("Failed to extend slave file download write deadline")
 	}
 
 	file, err := os.Open(realPath)
@@ -247,6 +259,10 @@ func (s *Server) handleFileScanByContent(w http.ResponseWriter, r *http.Request)
 		Success: err == nil,
 	}
 	if err != nil {
+		log.WithFields(log.Fields{
+			"taskName": req.TaskID,
+			"scanMode": "content_time",
+		}).WithError(err).Error("Slave file scan failed")
 		resp.ErrorCode = scanErrorCode(err)
 		resp.Error = err.Error()
 	}
@@ -289,8 +305,7 @@ func (s *Server) scanFilesByContent(taskID string, scanFolders []string, additio
 		log.WithField("taskName", taskID).Infof("os does not support birth time, will use modification time for content time filtering")
 
 		if s.collectFileStateHandler == nil {
-			log.WithField("taskName", taskID).Errorf("collect file state handler is nil")
-			return result, nil
+			return result, errors.New("collect file state handler is unavailable")
 		}
 
 		// Update cache via file_state_handler using provided scan folders
@@ -299,8 +314,7 @@ func (s *Server) scanFilesByContent(taskID string, scanFolders []string, additio
 			RecursivelyWalkDirs: recursivelyWalkDirs,
 		}
 		if err := s.collectFileStateHandler.UpdateCollectDirs(whiteList, conf); err != nil {
-			log.Errorf("file state handler update collect dirs: %v", err)
-			return result, nil
+			return result, errors.Wrap(err, "update collect directories in file state handler")
 		}
 
 		// Build filters: collecting + time overlap
@@ -383,6 +397,6 @@ func scanErrorCode(err error) string {
 	case errors.Is(err, upload.ErrTimeWindowNotReady):
 		return master.TaskErrorCodeTimeWindowNotReady
 	default:
-		return ""
+		return master.TaskErrorCodeInternal
 	}
 }

--- a/internal/slave/server_test.go
+++ b/internal/slave/server_test.go
@@ -34,10 +34,12 @@ import (
 
 type updateCollectDirsErrorHandler struct{}
 
+var errUpdateCollectDirs = errors.New("update collect directories failed")
+
 func (updateCollectDirsErrorHandler) UpdateListenDirs(config.DefaultModConfConfig) error { return nil }
 
 func (updateCollectDirsErrorHandler) UpdateCollectDirs([]string, config.DefaultModConfConfig) error {
-	return errors.New("update collect directories failed")
+	return errUpdateCollectDirs
 }
 
 func (updateCollectDirsErrorHandler) Files(...file_state_handler.FileFilter) []file_state_handler.FileState {

--- a/internal/slave/server_test.go
+++ b/internal/slave/server_test.go
@@ -120,6 +120,44 @@ func TestScanFilesByContentRejectsInvalidWindowBeforeFilesystemAccess(t *testing
 	}
 }
 
+func TestFileScanByContentReportsUnavailableStateHandler(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	server := &Server{
+		hasBirthTime: func([]string) bool {
+			return false
+		},
+	}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(master.TaskRequest{
+		TaskID:    "missing-state-handler",
+		StartTime: now.Add(-time.Minute).Unix(),
+		EndTime:   now.Unix(),
+	}); err != nil {
+		t.Fatalf("encode request: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/", &body)
+	server.handleFileScanByContent(recorder, request)
+
+	var response master.TaskResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Success {
+		t.Fatalf("response = %+v, want an explicit failure", response)
+	}
+	if response.ErrorCode != master.TaskErrorCodeInternal {
+		t.Fatalf("error code = %q, want %q", response.ErrorCode, master.TaskErrorCodeInternal)
+	}
+	if response.Error == "" {
+		t.Fatalf("response = %+v, want diagnostic error text", response)
+	}
+}
+
 func TestFileScanHandlersReturnTimeWindowOutcomes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/slave/server_test.go
+++ b/internal/slave/server_test.go
@@ -20,13 +20,58 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/coscene-io/coscout/internal/config"
 	"github.com/coscene-io/coscout/internal/master"
+	"github.com/coscene-io/coscout/internal/mod/rule/file_handlers"
+	"github.com/coscene-io/coscout/internal/mod/rule/file_state_handler"
 	"github.com/coscene-io/coscout/pkg/upload"
 )
+
+type updateCollectDirsErrorHandler struct{}
+
+func (updateCollectDirsErrorHandler) UpdateListenDirs(config.DefaultModConfConfig) error { return nil }
+
+func (updateCollectDirsErrorHandler) UpdateCollectDirs([]string, config.DefaultModConfConfig) error {
+	return errors.New("update collect directories failed")
+}
+
+func (updateCollectDirsErrorHandler) Files(...file_state_handler.FileFilter) []file_state_handler.FileState {
+	return nil
+}
+
+func (updateCollectDirsErrorHandler) UpdateFilesProcessState() error { return nil }
+
+func (updateCollectDirsErrorHandler) MarkProcessedFile(string) error { return nil }
+
+func (updateCollectDirsErrorHandler) GetFileHandler(string) file_handlers.Interface { return nil }
+
+type deadlineResponseWriter struct {
+	header   http.Header
+	body     bytes.Buffer
+	status   int
+	deadline time.Time
+}
+
+func (w *deadlineResponseWriter) Header() http.Header { return w.header }
+
+func (w *deadlineResponseWriter) Write(data []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.body.Write(data)
+}
+
+func (w *deadlineResponseWriter) WriteHeader(status int) { w.status = status }
+
+func (w *deadlineResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	w.deadline = deadline
+	return nil
+}
 
 func TestScanFilesRejectsInvalidWindowBeforeFilesystemAccess(t *testing.T) {
 	t.Parallel()
@@ -155,6 +200,73 @@ func TestFileScanByContentReportsUnavailableStateHandler(t *testing.T) {
 	}
 	if response.Error == "" {
 		t.Fatalf("response = %+v, want diagnostic error text", response)
+	}
+}
+
+func TestFileScanByContentReportsCollectDirectoryUpdateFailure(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	server := &Server{
+		hasBirthTime:            func([]string) bool { return false },
+		collectFileStateHandler: updateCollectDirsErrorHandler{},
+	}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(master.TaskRequest{
+		TaskID:    "collect-dir-update-failure",
+		StartTime: now.Add(-time.Minute).Unix(),
+		EndTime:   now.Unix(),
+	}); err != nil {
+		t.Fatalf("encode request: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	server.handleFileScanByContent(recorder, httptest.NewRequest(http.MethodPost, "/", &body))
+
+	var response master.TaskResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Success {
+		t.Fatalf("response = %+v, want an explicit failure", response)
+	}
+	if response.ErrorCode != master.TaskErrorCodeInternal {
+		t.Fatalf("error code = %q, want %q", response.ErrorCode, master.TaskErrorCodeInternal)
+	}
+	if response.Error == "" {
+		t.Fatalf("response = %+v, want diagnostic error text", response)
+	}
+}
+
+func TestFileDownloadExtendsWriteDeadlineAndStreamsFile(t *testing.T) {
+	t.Parallel()
+
+	filePath := filepath.Join(t.TempDir(), "download.txt")
+	const contents = "download payload"
+	if err := os.WriteFile(filePath, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	var requestBody bytes.Buffer
+	if err := json.NewEncoder(&requestBody).Encode(master.FileTransferRequest{FilePath: filePath}); err != nil {
+		t.Fatalf("encode request: %v", err)
+	}
+
+	writer := &deadlineResponseWriter{header: make(http.Header)}
+	startedAt := time.Now()
+	(&Server{}).handleFileDownload(writer, httptest.NewRequest(http.MethodPost, "/", &requestBody))
+
+	if writer.status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", writer.status, http.StatusOK)
+	}
+	if writer.body.String() != contents {
+		t.Fatalf("body = %q, want %q", writer.body.String(), contents)
+	}
+	minDeadline := startedAt.Add(config.DefaultFileTransferTimeout - 5*time.Second)
+	maxDeadline := time.Now().Add(config.DefaultFileTransferTimeout + 5*time.Second)
+	if writer.deadline.Before(minDeadline) || writer.deadline.After(maxDeadline) {
+		t.Fatalf("write deadline = %v, want approximately %v from now", writer.deadline, config.DefaultFileTransferTimeout)
 	}
 }
 


### PR DESCRIPTION
## Summary

Slave content-scan failures no longer look like successful empty scans. The slave now returns an explicit internal error and the master logs the failed node while preserving the accepted partial-success behavior for available results.

Large remote files can also finish transferring beyond the ordinary 60-second request timeout. Connection setup and response headers remain bounded, while the response body and slave write deadline use the existing 30-minute transfer window and still honor caller cancellation.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/master ./internal/slave ./internal/collector`
- Regression coverage verifies delayed response headers, response bodies that outlive the request timeout, caller cancellation, state-handler failures, and the slave write deadline.

## Post-Deploy Monitoring & Validation

- Search logs for `Slave file scan failed`, `continuing with available results`, `failed to download slave file to local cache`, and `context deadline exceeded`.
- Watch coScout CPU, RSS, goroutine count, open file descriptors, download throughput, and repeated slave-download retries.
- Healthy signal: internal scan failures identify the task and slave explicitly; large downloads continue beyond 60 seconds and complete within the 30-minute ceiling.
- Failure signal: sustained growth in goroutines/file descriptors, repeated deadline errors for the same remote file, or download retries without progress. Roll back this PR if those signals persist after confirming network and disk health.
- Validation window: first 24 hours after deployment; owner: service on-call.

## New concepts

### Phase-specific HTTP timeouts

An HTTP request has separate phases, and a single client timeout covers all of them. That is useful for short API calls but prematurely terminates a healthy large response body.

| Phase | Bound in this PR | Purpose |
|---|---:|---|
| Response headers | normal request timeout | Detect an unresponsive slave quickly |
| Response body | caller context, up to 30 minutes | Allow large files to stream without a 60-second cutoff |
| Server writes | 30 minutes | Keep the slave from closing a healthy long transfer |

This split is appropriate for bounded streaming transfers. For small responses, a single end-to-end client timeout remains simpler and safer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coScout/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787897372&installation_model_id=425002&pr_number=229&repository=coscene-io%2FcoScout&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoScout%2Fpull%2F229&signature=6b62a0be8dd58163f3dac76a54351adebded3f8a8e9b236534d843f315634365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->