### PR TITLE
fix(upload): upload latest complete slave content

### DIFF
--- a/internal/collector/upload.go
+++ b/internal/collector/upload.go
@@ -959,8 +959,9 @@ func uploadSlaveFile(ctx context.Context, reqClient *api.RequestClient, appConfi
 	if err != nil {
 		log.Warnf("Failed to get actual file size for %s: %v", localCachePath, err)
 	} else {
+		previousSize := fileInfo.Size
 		fileInfo.Size = actualSize
-		log.Infof("Updated file size from %d to %d for %s", fileInfo.Size, actualSize, localCachePath)
+		log.Infof("Updated file size from %d to %d for %s", previousSize, actualSize, localCachePath)
 	}
 
 	// Continue with standard upload logic
@@ -1031,18 +1032,10 @@ func downloadSlaveFileToLocal(parentCtx context.Context, fileManager *master.Fil
 	// Copy complete content to local file (no size limit)
 	bytesCopied, err := io.Copy(localFile, reader)
 	if err != nil {
-		// Clean up on error
-		err := os.Remove(localPath)
-		if err != nil {
-			return err
+		if removeErr := os.Remove(localPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			return errors.Wrapf(err, "failed to copy slave file content and remove incomplete cache file: %v", removeErr)
 		}
 		return errors.Wrap(err, "failed to copy slave file content")
-	}
-	if fileInfo.Size > 0 && bytesCopied != fileInfo.Size {
-		if err := os.Remove(localPath); err != nil && !os.IsNotExist(err) {
-			log.Warnf("failed to remove incomplete slave cache file %s: %v", localPath, err)
-		}
-		return errors.Errorf("slave file size mismatch after download: path=%s copied=%d expected=%d", fileInfo.Path, bytesCopied, fileInfo.Size)
 	}
 
 	log.Infof("Successfully downloaded slave file to local cache: %s (copied %d bytes)", localPath, bytesCopied)

--- a/internal/collector/upload_test.go
+++ b/internal/collector/upload_test.go
@@ -28,49 +28,99 @@ import (
 	"github.com/coscene-io/coscout/internal/model"
 )
 
-func TestDownloadSlaveFileToLocalRejectsShortRead(t *testing.T) {
+func TestDownloadSlaveFileToLocalUsesLatestCompleteContent(t *testing.T) {
 	t.Parallel()
 
 	const slaveID = "0011223344556677"
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/files/download" {
-			http.NotFound(w, r)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte("short")); err != nil {
-			t.Errorf("failed to write response: %v", err)
-		}
-	}))
-	defer server.Close()
-
-	host, portStr, err := net.SplitHostPort(server.Listener.Addr().String())
-	if err != nil {
-		t.Fatalf("failed to parse test server address: %v", err)
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		t.Fatalf("failed to parse test server port: %v", err)
-	}
-
-	registry := master.NewSlaveRegistry()
-	if err := registry.Register(&master.SlaveInfo{ID: slaveID, IP: host, Port: port}); err != nil {
-		t.Fatalf("failed to register slave: %v", err)
-	}
-	fileManager := master.NewFileManager(master.NewClient(config.DefaultMasterConfig()), registry)
-
-	localPath := filepath.Join(t.TempDir(), "cached-slave-file")
-	fileInfo := &model.FileInfo{
-		Path: "slave://" + slaveID + "/tmp/source.bag",
-		Size: 10,
+	tests := []struct {
+		name          string
+		content       string
+		contentLength int64
+		scannedSize   int64
+		wantErr       bool
+	}{
+		{
+			name:        "accepts file truncated after scan",
+			content:     "short",
+			scannedSize: 10,
+			wantErr:     false,
+		},
+		{
+			name:        "accepts file appended after scan",
+			content:     "complete-and-appended",
+			scannedSize: 8,
+			wantErr:     false,
+		},
+		{
+			name:          "rejects truncated HTTP response",
+			content:       "short",
+			contentLength: 10,
+			scannedSize:   10,
+			wantErr:       true,
+		},
 	}
 
-	err = downloadSlaveFileToLocal(t.Context(), fileManager, fileInfo, localPath, 0)
-	if err == nil {
-		t.Fatal("expected short slave download to fail")
-	}
-	if _, statErr := os.Stat(localPath); !os.IsNotExist(statErr) {
-		t.Fatalf("expected incomplete cache file to be removed, stat err: %v", statErr)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/v1/files/download" {
+					http.NotFound(w, r)
+					return
+				}
+				if tt.contentLength > 0 {
+					w.Header().Set("Content-Length", strconv.FormatInt(tt.contentLength, 10))
+				}
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write([]byte(tt.content)); err != nil {
+					t.Errorf("failed to write response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			host, portStr, err := net.SplitHostPort(server.Listener.Addr().String())
+			if err != nil {
+				t.Fatalf("failed to parse test server address: %v", err)
+			}
+			port, err := strconv.Atoi(portStr)
+			if err != nil {
+				t.Fatalf("failed to parse test server port: %v", err)
+			}
+
+			registry := master.NewSlaveRegistry()
+			if err := registry.Register(&master.SlaveInfo{ID: slaveID, IP: host, Port: port}); err != nil {
+				t.Fatalf("failed to register slave: %v", err)
+			}
+			fileManager := master.NewFileManager(master.NewClient(config.DefaultMasterConfig()), registry)
+
+			localPath := filepath.Join(t.TempDir(), "cached-slave-file")
+			fileInfo := &model.FileInfo{
+				Path: "slave://" + slaveID + "/tmp/source.bag",
+				Size: tt.scannedSize,
+			}
+
+			err = downloadSlaveFileToLocal(t.Context(), fileManager, fileInfo, localPath, 0)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected truncated slave download to fail")
+				}
+				if _, statErr := os.Stat(localPath); !os.IsNotExist(statErr) {
+					t.Fatalf("expected incomplete cache file to be removed, stat err: %v", statErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected complete slave file download to succeed: %v", err)
+			}
+			data, err := os.ReadFile(localPath)
+			if err != nil {
+				t.Fatalf("failed to read cached slave file: %v", err)
+			}
+			if string(data) != tt.content {
+				t.Fatalf("cached content = %q, want %q", string(data), tt.content)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Slave uploads no longer get stuck when a file grows, rotates, or shrinks after it was scanned. The master now treats a successfully completed download as the latest full content, refreshes the size from the local cache, and continues uploading instead of comparing against stale scan metadata.

Real transport truncation still fails: copy errors are preserved and partial cache files are removed. Validated with `make shortlint` and `go test ./...`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coScout/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787907582&installation_model_id=425002&pr_number=230&repository=coscene-io%2FcoScout&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoScout%2Fpull%2F230&signature=5bd7a578c4cd6c5a1810c89b3374f6c28838301024dc7338d208e2f1e51de692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->