### PR TITLE
fix(rule): wait for complete collection window

### DIFF
--- a/internal/mod/rule/handler.go
+++ b/internal/mod/rule/handler.go
@@ -535,17 +535,7 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 		return
 	}
 
-	if err := upload.ValidateTimeWindow(info.Cut.Start, info.Cut.End); err != nil {
-		if errors.Is(err, upload.ErrTimeWindowNotReady) {
-			collectLog.WithFields(log.Fields{
-				"start": info.Cut.Start,
-				"end":   info.Cut.End,
-			}).Infof("collect info starts beyond the future tolerance and will be consumed as an empty successful scan: %v", err)
-			if cleanedPath := c.clean(info); cleanedPath == "" {
-				collectLog.Errorf("failed to clean future collect info after empty successful scan")
-			}
-			return
-		}
+	if err := upload.ValidateTimeWindow(info.Cut.Start, info.Cut.End); errors.Is(err, upload.ErrInvalidTimeWindow) {
 		collectLog.WithFields(log.Fields{
 			"start": info.Cut.Start,
 			"end":   info.Cut.End,
@@ -553,6 +543,14 @@ func (c *CustomRuleHandler) handleCollectInfo(info model.CollectInfo, modConfig 
 		if cleanedPath := c.clean(info); cleanedPath == "" {
 			collectLog.Errorf("failed to clean collect info with permanently invalid time window")
 		}
+		return
+	}
+
+	if time.Unix(info.Cut.End, 0).After(time.Now()) {
+		collectLog.WithFields(log.Fields{
+			"start": info.Cut.Start,
+			"end":   info.Cut.End,
+		}).Info("collect info end time has not been reached, waiting for the complete collection window")
 		return
 	}
 

--- a/internal/mod/rule/handler_test.go
+++ b/internal/mod/rule/handler_test.go
@@ -40,10 +40,16 @@ func TestHandleCollectInfoTimeWindowLifecycle(t *testing.T) {
 		wantStateScan bool
 	}{
 		{
-			name:      "future local window is consumed as empty success",
+			name:      "future local window waits for end",
 			start:     now.Add(10 * time.Minute),
 			end:       now.Add(20 * time.Minute),
-			wantClean: true,
+			wantClean: false,
+		},
+		{
+			name:      "active after window waits for end",
+			start:     now.Add(-time.Minute),
+			end:       now.Add(time.Minute),
+			wantClean: false,
 		},
 		{
 			name:      "invalid local window is cleaned",
@@ -53,8 +59,8 @@ func TestHandleCollectInfoTimeWindowLifecycle(t *testing.T) {
 		},
 		{
 			name:  "invalid slave window wins and is cleaned",
-			start: now.Add(-time.Minute),
-			end:   now.Add(time.Minute),
+			start: now.Add(-2 * time.Minute),
+			end:   now.Add(-time.Minute),
 			responses: map[string]*master.TaskResponse{
 				"future": {
 					Success:   false,


### PR DESCRIPTION
Rule-triggered collections with a positive `after` window now remain pending until `Cut.End`, so files produced during the full configured window stay eligible for collection. Previously, future-ended windows were scanned and cleaned immediately, dropping data written during the remaining window.

Permanently invalid windows (`Start > End`) are still rejected and cleaned. Lifecycle coverage now includes both fully future windows and already-active `after` windows; `go test ./...`, the rule package race tests, and `make shortlint` pass.

Related: #227

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coScout/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787909424&installation_model_id=425002&pr_number=231&repository=coscene-io%2FcoScout&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoScout%2Fpull%2F231&signature=4376835edb9614b5b3877c6e66d768457c882f7a3c7dc958ec6d69458a6fc347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->